### PR TITLE
Remove the chapter names in the display of positions in the UI

### DIFF
--- a/palamedes/dashboard/templates/dashboard/directory.html
+++ b/palamedes/dashboard/templates/dashboard/directory.html
@@ -97,7 +97,7 @@
                     </span>
 
                     <p class="card-text text-muted small mb-1">
-                        <i class="fas fa-graduation-cap"></i> {{ member.position|default:"No Position" }}
+                        <i class="fas fa-graduation-cap"></i> {{ member.position.title|default:"No Position" }}
                     </p>
                 </div>
 

--- a/palamedes/dashboard/templates/dashboard/unpaid_directory.html
+++ b/palamedes/dashboard/templates/dashboard/unpaid_directory.html
@@ -41,8 +41,8 @@
                     <div class="input-group-prepend">
                         <div class="input-group-text"><i class="fas fa-search"></i></div>
                     </div>
-                    <input type="text" name="filter" class="form-control" placeholder="Search name, major, or hometown..."
-                        value="{{ search_query }}">
+                    <input type="text" name="filter" class="form-control"
+                        placeholder="Search name, major, or hometown..." value="{{ search_query }}">
                 </div>
 
                 <select name="status" class="custom-select mb-2 mr-sm-2">
@@ -123,7 +123,7 @@
 
                         <td class="align-middle">
                             {% if member.position %}
-                            {{ member.position }}
+                            {{ member.position.title }}
                             {% else %}
                             <span class="text-muted small">&mdash;</span>
                             {% endif %}


### PR DESCRIPTION
In some location across the UI, we used the default display of the Position model which included Chapter Name. This would be redundant for an user logging in on their account and seeing their Chapter Name everywhere on their feed, which is not neccessary.