### PR TITLE
Test suite Phase 1: homepage app

### DIFF
--- a/docs/testing/progress.md
+++ b/docs/testing/progress.md
@@ -45,11 +45,36 @@ C:\Users\sidan\anaconda3\envs\palamedes\python.exe -m coverage report -m
 - Verified: `manage.py test` and `coverage run manage.py test && coverage report`
   both run clean with 0 tests, 0 errors.
 
-Branch: `tests/phase-0-infra`. Not yet merged to `main` — pending user check-in.
+Branch: `tests/phase-0-infra`. Merged to `main` via PR #43 (admin override — main
+requires a review approval and no CI is configured, so a straight `gh pr merge`
+was blocked; user chose to bypass with `--admin`).
 
-## Phase 1 — `homepage` app — not started
+## Phase 1 — `homepage` app — **DONE**
 
-Stub files ready at `homepage/tests/{test_models,test_forms,test_views,test_admin}.py`.
+24 tests added, homepage app (models.py, forms.py, views.py, admin.py) at **100%**
+line coverage.
+
+- `test_models.py` (4 tests): `ChapterRequest.__str__`, `is_approved` default,
+  `date_requested` auto-population, direct approval.
+- `test_forms.py` (6 tests): `ChapterRequestForm` valid submission, each required
+  field's validation error, malformed email, `save()` persistence.
+- `test_views.py` (7 tests): `home` (anon vs. authenticated redirect), `about`
+  context, `start_chapter` GET/valid-POST/invalid-POST (incl. success message
+  and DB row assertions). Had to work around a real environment gotcha:
+  `base.html` uses `{% static %}` and WhiteNoise's
+  `CompressedManifestStaticFilesStorage` needs a `collectstatic` manifest that
+  doesn't exist here, so full-page-rendering tests use
+  `override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")`.
+  **This same workaround will be needed in every future phase that renders a
+  full page** (dashboard templates also extend a base with `{% static %}` —
+  confirm/reuse this pattern rather than rediscovering it).
+- `test_admin.py` (7 tests): `approve_requests` action — `is_approved` flip,
+  Chapter `get_or_create` + invite codes, all 4 Position rows' exact permission
+  flags, approval email content/recipient, skip-if-already-approved, idempotent
+  on a second run, and backfilling codes onto a pre-existing codeless Chapter.
+
+Branch: `tests/phase-1-homepage`, 4 commits (one per test file), not yet merged —
+pending user check-in.
 
 ## Phase 2 — `users` app — not started
 
@@ -80,6 +105,14 @@ tightly coupled to that app).
 
 ---
 
-## Current coverage snapshot
+## Current coverage snapshot (after Phase 1)
 
-Not yet measured with real tests (0 tests exist beyond stubs as of Phase 0).
+`coverage run manage.py test && coverage report -m` (full suite, 24 tests):
+
+- `homepage/`: **100%** across `models.py`, `forms.py`, `views.py`, `admin.py`.
+- Everything else (users, dashboard, palamedes settings/urls): unchanged from
+  the Phase 0 baseline (module-level-only coverage from imports, no real
+  tests yet) — that's Phases 2-7.
+- Project `TOTAL`: 48% (up from the Phase 0 baseline of 43%), but this number
+  is dominated by dashboard/users still having no real tests — not a
+  meaningful project-wide signal until later phases land.

--- a/palamedes/homepage/tests/test_admin.py
+++ b/palamedes/homepage/tests/test_admin.py
@@ -1,3 +1,109 @@
+from django.core import mail
 from django.test import TestCase
 
-# ChapterRequestAdmin.approve_requests action tests — Phase 1.
+from homepage.admin import approve_requests
+from homepage.models import ChapterRequest
+from users.models import Chapter, Position
+
+
+class ApproveRequestsActionTests(TestCase):
+    def make_request(self, **overrides):
+        data = dict(
+            fraternity_name="Theta Chi",
+            university="UC Riverside",
+            president_email="president@example.com",
+        )
+        data.update(overrides)
+        return ChapterRequest.objects.create(**data)
+
+    def test_marks_request_approved(self):
+        req = self.make_request()
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        req.refresh_from_db()
+        self.assertTrue(req.is_approved)
+
+    def test_creates_chapter_matching_request(self):
+        req = self.make_request()
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        chapter = Chapter.objects.get(name="Theta Chi", university="UC Riverside")
+        self.assertIsNotNone(chapter.nm_invite_code)
+        self.assertIsNotNone(chapter.active_invite_code)
+        self.assertNotEqual(chapter.nm_invite_code, chapter.active_invite_code)
+
+    def test_creates_four_positions_with_correct_flags(self):
+        req = self.make_request()
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        chapter = Chapter.objects.get(name="Theta Chi", university="UC Riverside")
+        positions = {p.title: p for p in chapter.positions.all()}
+
+        self.assertEqual(
+            set(positions.keys()),
+            {"President", "Vice President", "Treasurer", "No Position"},
+        )
+
+        president = positions["President"]
+        self.assertTrue(president.can_manage_roster)
+        self.assertTrue(president.can_manage_finance)
+        self.assertTrue(president.can_manage_points)
+        self.assertTrue(president.can_manage_tasks)
+        self.assertTrue(president.can_create_positions)
+        self.assertTrue(president.can_manage_nm_points)
+
+        vp = positions["Vice President"]
+        self.assertTrue(vp.can_manage_roster)
+        self.assertFalse(vp.can_manage_finance)
+        self.assertTrue(vp.can_manage_points)
+        self.assertTrue(vp.can_manage_tasks)
+        self.assertFalse(vp.can_create_positions)
+        self.assertTrue(vp.can_manage_nm_points)
+
+        treasurer = positions["Treasurer"]
+        self.assertFalse(treasurer.can_manage_roster)
+        self.assertTrue(treasurer.can_manage_finance)
+        self.assertFalse(treasurer.can_manage_points)
+        self.assertFalse(treasurer.can_manage_tasks)
+        self.assertFalse(treasurer.can_create_positions)
+        self.assertFalse(treasurer.can_manage_nm_points)
+
+        no_position = positions["No Position"]
+        self.assertFalse(no_position.can_manage_roster)
+        self.assertFalse(no_position.can_manage_finance)
+        self.assertFalse(no_position.can_manage_points)
+        self.assertFalse(no_position.can_manage_tasks)
+        self.assertFalse(no_position.can_create_positions)
+        self.assertFalse(no_position.can_manage_nm_points)
+
+    def test_sends_approval_email_to_president(self):
+        req = self.make_request(president_email="prez@example.com")
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["prez@example.com"])
+        self.assertIn("Theta Chi", mail.outbox[0].subject)
+
+    def test_already_approved_request_is_skipped(self):
+        req = self.make_request(is_approved=True)
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        self.assertEqual(Chapter.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_running_twice_does_not_duplicate_chapter_or_positions(self):
+        req = self.make_request()
+        qs = ChapterRequest.objects.filter(pk=req.pk)
+        approve_requests(None, None, qs)
+        # Second run is a no-op because req.is_approved is now True and the
+        # loop skips already-approved requests.
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        self.assertEqual(Chapter.objects.count(), 1)
+        self.assertEqual(Position.objects.count(), 4)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_existing_chapter_without_codes_gets_backfilled(self):
+        # Simulates a chapter created some other way (e.g. manually in
+        # admin) before a matching ChapterRequest gets approved.
+        Chapter.objects.create(name="Theta Chi", university="UC Riverside")
+        req = self.make_request()
+        approve_requests(None, None, ChapterRequest.objects.filter(pk=req.pk))
+        self.assertEqual(Chapter.objects.count(), 1)
+        chapter = Chapter.objects.get()
+        self.assertIsNotNone(chapter.nm_invite_code)
+        self.assertIsNotNone(chapter.active_invite_code)

--- a/palamedes/homepage/tests/test_forms.py
+++ b/palamedes/homepage/tests/test_forms.py
@@ -1,3 +1,45 @@
 from django.test import TestCase
 
-# ChapterRequestForm tests — Phase 1.
+from homepage.forms import ChapterRequestForm
+
+
+class ChapterRequestFormTests(TestCase):
+    def valid_data(self, **overrides):
+        data = {
+            "fraternity_name": "Theta Chi",
+            "university": "UC Riverside",
+            "president_email": "president@example.com",
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_data_is_valid(self):
+        form = ChapterRequestForm(data=self.valid_data())
+        self.assertTrue(form.is_valid())
+
+    def test_missing_fraternity_name_is_invalid(self):
+        form = ChapterRequestForm(data=self.valid_data(fraternity_name=""))
+        self.assertFalse(form.is_valid())
+        self.assertIn("fraternity_name", form.errors)
+
+    def test_missing_university_is_invalid(self):
+        form = ChapterRequestForm(data=self.valid_data(university=""))
+        self.assertFalse(form.is_valid())
+        self.assertIn("university", form.errors)
+
+    def test_missing_president_email_is_invalid(self):
+        form = ChapterRequestForm(data=self.valid_data(president_email=""))
+        self.assertFalse(form.is_valid())
+        self.assertIn("president_email", form.errors)
+
+    def test_malformed_president_email_is_invalid(self):
+        form = ChapterRequestForm(data=self.valid_data(president_email="not-an-email"))
+        self.assertFalse(form.is_valid())
+        self.assertIn("president_email", form.errors)
+
+    def test_save_persists_chapter_request(self):
+        form = ChapterRequestForm(data=self.valid_data())
+        self.assertTrue(form.is_valid())
+        req = form.save()
+        self.assertEqual(req.fraternity_name, "Theta Chi")
+        self.assertFalse(req.is_approved)

--- a/palamedes/homepage/tests/test_models.py
+++ b/palamedes/homepage/tests/test_models.py
@@ -1,3 +1,38 @@
 from django.test import TestCase
 
-# ChapterRequest model tests — Phase 1.
+from homepage.models import ChapterRequest
+
+
+class ChapterRequestModelTests(TestCase):
+    def test_str_includes_fraternity_name_and_university(self):
+        req = ChapterRequest.objects.create(
+            fraternity_name="Theta Chi",
+            university="UC Riverside",
+            president_email="president@example.com",
+        )
+        self.assertEqual(str(req), "Theta Chi at UC Riverside")
+
+    def test_is_approved_defaults_to_false(self):
+        req = ChapterRequest.objects.create(
+            fraternity_name="Theta Chi",
+            university="UC Riverside",
+            president_email="president@example.com",
+        )
+        self.assertFalse(req.is_approved)
+
+    def test_date_requested_auto_populates_on_create(self):
+        req = ChapterRequest.objects.create(
+            fraternity_name="Theta Chi",
+            university="UC Riverside",
+            president_email="president@example.com",
+        )
+        self.assertIsNotNone(req.date_requested)
+
+    def test_can_be_marked_approved(self):
+        req = ChapterRequest.objects.create(
+            fraternity_name="Theta Chi",
+            university="UC Riverside",
+            president_email="president@example.com",
+            is_approved=True,
+        )
+        self.assertTrue(req.is_approved)

--- a/palamedes/homepage/tests/test_views.py
+++ b/palamedes/homepage/tests/test_views.py
@@ -1,3 +1,89 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.urls import reverse
 
-# home / about / start_chapter view tests — Phase 1.
+from homepage.models import ChapterRequest
+from palamedes.test_helpers import make_user
+
+# base.html (extended by every homepage template) references {% static %}
+# assets. STATICFILES_STORAGE is WhiteNoise's CompressedManifestStaticFilesStorage
+# in settings.py, which requires a collectstatic-generated manifest that
+# doesn't exist in this test environment. Swap to the plain storage backend
+# for any test that renders a full page, or `{% static %}` raises
+# ValueError: Missing staticfiles manifest entry (see codebase-notes.md §2).
+_PLAIN_STATIC_STORAGE = override_settings(
+    STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage"
+)
+
+
+@_PLAIN_STATIC_STORAGE
+class HomeViewTests(TestCase):
+    def test_anonymous_user_sees_landing_page(self):
+        response = self.client.get(reverse("home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "homepage/home.html")
+
+    def test_authenticated_user_is_redirected_to_dashboard(self):
+        user = make_user()
+        self.client.force_login(user)
+        response = self.client.get(reverse("home"))
+        self.assertRedirects(response, reverse("dashboard"))
+
+
+@_PLAIN_STATIC_STORAGE
+class AboutViewTests(TestCase):
+    def test_renders_about_page_with_title(self):
+        response = self.client.get(reverse("about"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "homepage/about.html")
+        self.assertEqual(response.context["title"], "About")
+
+
+@_PLAIN_STATIC_STORAGE
+class StartChapterViewTests(TestCase):
+    def test_get_renders_empty_form(self):
+        response = self.client.get(reverse("start_chapter"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "homepage/start_chapter.html")
+        self.assertFalse(response.context["form"].is_bound)
+
+    def test_valid_post_creates_request_and_redirects_home(self):
+        response = self.client.post(
+            reverse("start_chapter"),
+            data={
+                "fraternity_name": "Theta Chi",
+                "university": "UC Riverside",
+                "president_email": "president@example.com",
+            },
+        )
+        self.assertRedirects(response, reverse("home"))
+        self.assertEqual(ChapterRequest.objects.count(), 1)
+        req = ChapterRequest.objects.get()
+        self.assertEqual(req.fraternity_name, "Theta Chi")
+
+    def test_valid_post_adds_success_message(self):
+        response = self.client.post(
+            reverse("start_chapter"),
+            data={
+                "fraternity_name": "Theta Chi",
+                "university": "UC Riverside",
+                "president_email": "president@example.com",
+            },
+            follow=True,
+        )
+        messages = list(response.context["messages"])
+        self.assertEqual(len(messages), 1)
+        self.assertIn("submitted", str(messages[0]))
+
+    def test_invalid_post_rerenders_form_with_errors(self):
+        response = self.client.post(
+            reverse("start_chapter"),
+            data={
+                "fraternity_name": "",
+                "university": "UC Riverside",
+                "president_email": "president@example.com",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "homepage/start_chapter.html")
+        self.assertTrue(response.context["form"].errors)
+        self.assertEqual(ChapterRequest.objects.count(), 0)


### PR DESCRIPTION
## Summary
- Phase 1 of the multi-phase test suite effort (see docs/testing/progress.md for the full phase plan and status).
- Adds 24 tests covering the entire homepage app: ChapterRequest model, ChapterRequestForm, the home/about/start_chapter views, and the approve_requests admin action (Chapter + 4-Position creation with exact permission flags, invite codes, approval email, idempotency, backfill-on-existing-chapter).
- Result: homepage/ app (models.py, forms.py, views.py, admin.py) at 100% line coverage.
- Also documents and works around a real environment gotcha: base.html uses {% static %} and WhiteNoise's CompressedManifestStaticFilesStorage needs a collectstatic manifest that doesn't exist here, so full-page-render tests override STATICFILES_STORAGE to a manifest-free backend. This will recur in later phases touching dashboard templates.
- No production code changes -- tests only, per the earlier bug-handling decision (pin current behavior, don't fix).

## Test plan
- [x] python manage.py test homepage -- 24 tests, all pass
- [x] python manage.py test (full suite) -- all pass, no regressions from Phase 0
- [x] coverage run manage.py test && coverage report -m -- homepage/ at 100%

Generated with Claude Code
