### PR TITLE
Test suite Phase 3: dashboard models & simple forms

### DIFF
--- a/docs/testing/progress.md
+++ b/docs/testing/progress.md
@@ -118,9 +118,37 @@ the PR is ready and let them merge it (UI or CLI) rather than retrying.**
 
 Branch: `tests/phase-2-users`, 4 commits, not yet merged — pending user check-in.
 
-## Phase 3 — `dashboard` models & simple forms — not started
+## Phase 3 — `dashboard` models & simple forms — **DONE**
 
-Stub files ready at `dashboard/tests/{test_models,test_forms}.py`.
+38 tests added. `dashboard/models.py` and `dashboard/forms.py` both at **100%**
+line coverage (`dashboard/admin.py` was already 100% — purely declarative).
+Full suite: 104 tests, all passing.
+
+- `test_models.py` (17 tests): `HousePoint` (`__str__`, status/date_for
+  defaults, negative amounts for penalties, `assigned_approver` SET_NULL),
+  `Due` (`__str__`, paid/template defaults, CASCADE-on-user-delete), `Task`
+  (`__str__`, completed default, mixed CASCADE/SET_NULL FKs), `Announcement`
+  (`__str__`, auto `date_posted`, CASCADE-on-chapter-delete).
+  **Hit a real Django/timezone gotcha here** — `HousePoint.date_for` has
+  `default=timezone.now` (a datetime-returning callable on a `DateField`), so
+  the in-memory attribute holds a raw datetime until it round-trips through
+  the DB; and comparing against `date.today()` (local system time) instead of
+  `timezone.now().date()` flaked because `TIME_ZONE='UTC'` in settings while
+  the test host's local clock is behind UTC. Fixed via `refresh_from_db()` +
+  comparing against `timezone.now().date()`. **Worth remembering for any
+  future date/time assertion in this codebase — always compare against UTC
+  clock sources, never local `date.today()`/`datetime.now()`.**
+- `test_forms.py` (21 tests): `NMPointRequestForm` (approver queryset scoped
+  to same-chapter Actives), `ActivePointRequestForm` (plain validation),
+  `DirectPointAssignmentForm` (can_manage_points-gated queryset, including the
+  `position=None` safe path), `SingleDueForm` (chapter-scoped queryset +
+  CHARGE/AID sign-forcing both directions), `BulkDueForm` (valid submission,
+  pinning that PLEDGE_CLASS's semester/year fields are NOT enforced by the
+  form itself — no `clean()` override, unlike BulkPointForm), `BulkPointForm`
+  (AWARD/PENALTY sign-forcing, `min_value=1`).
+
+Branch: `tests/phase-3-dashboard-core`, 2 commits, not yet merged — pending
+user check-in.
 
 ## Phase 4 — `dashboard` read-only/aggregation views — not started
 
@@ -143,17 +171,18 @@ tightly coupled to that app).
 
 ---
 
-## Current coverage snapshot (after Phase 2)
+## Current coverage snapshot (after Phase 3)
 
-`coverage run manage.py test && coverage report -m` (full suite, 66 tests):
+`coverage run manage.py test && coverage report -m` (full suite, 104 tests):
 
 - `homepage/`: **100%** across `models.py`, `forms.py`, `views.py`, `admin.py`.
 - `users/`: **100%** across `models.py`, `forms.py`, `views.py`, `urls.py`,
   `admin.py`.
-- `dashboard/`: unchanged from the Phase 0 baseline (module-level-only
-  coverage from imports, no real tests yet) — that's Phases 3-6.
+- `dashboard/`: `models.py`, `forms.py`, `admin.py`, `urls.py` all **100%**.
+  `views.py` at 16% (335/401 statements missing) — that's Phases 4-6, the
+  20-view file that's the bulk of remaining work.
 - `palamedes/settings.py` at 96% (missing the AWS S3 storage branch, only
   exercised when `AWS_ACCESS_KEY_ID` is set — out of scope for now).
-- Project `TOTAL`: 52% (up from 48% after Phase 1), still dominated by
-  dashboard having no tests yet — dashboard is roughly half the codebase by
-  line count (`dashboard/views.py` alone is 401 statements).
+- Project `TOTAL`: 60% (up from 52% after Phase 2). `dashboard/views.py`
+  (401 statements) is the single largest remaining gap — closing Phases
+  4-6 should push the project total well past 90%.

--- a/palamedes/dashboard/tests/test_forms.py
+++ b/palamedes/dashboard/tests/test_forms.py
@@ -1,4 +1,225 @@
+from datetime import date
+
 from django.test import TestCase
 
-# NMPointRequestForm / ActivePointRequestForm / DirectPointAssignmentForm /
-# SingleDueForm / BulkDueForm / BulkPointForm tests — Phase 3.
+from dashboard.forms import (
+    ActivePointRequestForm,
+    BulkDueForm,
+    BulkPointForm,
+    DateInput,
+    DirectPointAssignmentForm,
+    NMPointRequestForm,
+    SingleDueForm,
+)
+from palamedes.test_helpers import make_chapter_with_positions, make_user
+
+
+class DateInputWidgetTests(TestCase):
+    def test_input_type_is_date(self):
+        self.assertEqual(DateInput().input_type, "date")
+
+
+class NMPointRequestFormTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.nm_user = make_user(chapter=self.chapter, status="NM")
+        self.same_chapter_active = make_user(chapter=self.chapter, status="ACT")
+        self.same_chapter_nm = make_user(chapter=self.chapter, status="NM")
+        self.other_chapter, _ = make_chapter_with_positions(
+            name="Sigma Nu", nm_invite_code="OTHNM001", active_invite_code="OTHACT01"
+        )
+        self.other_chapter_active = make_user(chapter=self.other_chapter, status="ACT")
+
+    def test_approver_queryset_limited_to_actives_in_same_chapter(self):
+        form = NMPointRequestForm(self.nm_user)
+        queryset = form.fields["assigned_approver"].queryset
+        self.assertIn(self.same_chapter_active, queryset)
+        self.assertNotIn(self.same_chapter_nm, queryset)
+        self.assertNotIn(self.other_chapter_active, queryset)
+
+    def test_approver_field_relabeled_and_required(self):
+        form = NMPointRequestForm(self.nm_user)
+        self.assertEqual(
+            form.fields["assigned_approver"].label, "Request Approval From"
+        )
+        self.assertTrue(form.fields["assigned_approver"].required)
+
+    def test_valid_data_with_eligible_approver_is_valid(self):
+        form = NMPointRequestForm(
+            self.nm_user,
+            data={
+                "amount": 5,
+                "description": "Attended event",
+                "date_for": date.today(),
+                "assigned_approver": self.same_chapter_active.pk,
+            },
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_missing_approver_is_invalid(self):
+        form = NMPointRequestForm(
+            self.nm_user,
+            data={
+                "amount": 5,
+                "description": "Attended event",
+                "date_for": date.today(),
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("assigned_approver", form.errors)
+
+
+class ActivePointRequestFormTests(TestCase):
+    def test_valid_data_is_valid(self):
+        form = ActivePointRequestForm(
+            data={"amount": 5, "description": "Attended event", "date_for": date.today()}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_missing_amount_is_invalid(self):
+        form = ActivePointRequestForm(
+            data={"description": "Attended event", "date_for": date.today()}
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("amount", form.errors)
+
+    def test_has_no_assigned_approver_field(self):
+        form = ActivePointRequestForm()
+        self.assertNotIn("assigned_approver", form.fields)
+
+
+class DirectPointAssignmentFormTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.nm_member = make_user(chapter=self.chapter, status="NM")
+        self.active_member = make_user(chapter=self.chapter, status="ACT")
+
+    def test_can_manage_points_sees_whole_chapter(self):
+        manager = make_user(
+            chapter=self.chapter, status="ACT", position=self.positions["President"]
+        )
+        form = DirectPointAssignmentForm(manager)
+        queryset = form.fields["user"].queryset
+        self.assertIn(self.nm_member, queryset)
+        self.assertIn(self.active_member, queryset)
+        self.assertEqual(form.fields["user"].label, "Assign to Member")
+
+    def test_without_can_manage_points_sees_only_new_members(self):
+        limited_user = make_user(
+            chapter=self.chapter, status="ACT", position=self.positions["Treasurer"]
+        )
+        form = DirectPointAssignmentForm(limited_user)
+        queryset = form.fields["user"].queryset
+        self.assertIn(self.nm_member, queryset)
+        self.assertNotIn(self.active_member, queryset)
+        self.assertEqual(form.fields["user"].label, "Assign to New Member")
+
+    def test_user_with_no_position_does_not_crash_and_sees_only_new_members(self):
+        # position=None: __init__ uses getattr(request_user, 'position', None)
+        # defensively, unlike several dashboard views that access
+        # request.user.position.<flag> unguarded — see codebase-notes.md §6.
+        positionless_user = make_user(chapter=self.chapter, status="ACT", position=None)
+        form = DirectPointAssignmentForm(positionless_user)
+        queryset = form.fields["user"].queryset
+        self.assertIn(self.nm_member, queryset)
+        self.assertNotIn(self.active_member, queryset)
+
+
+class SingleDueFormTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.member = make_user(chapter=self.chapter)
+        self.requester = make_user(chapter=self.chapter, status="ACT")
+
+    def valid_data(self, **overrides):
+        data = {
+            "title": "Fall Dues",
+            "amount": 100,
+            "due_date": date.today(),
+            "assigned_to": self.member.pk,
+            "type": "CHARGE",
+        }
+        data.update(overrides)
+        return data
+
+    def test_charge_type_forces_amount_positive(self):
+        form = SingleDueForm(self.requester, data=self.valid_data(amount=-50, type="CHARGE"))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["amount"], 50)
+
+    def test_aid_type_forces_amount_negative(self):
+        form = SingleDueForm(self.requester, data=self.valid_data(amount=50, type="AID"))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["amount"], -50)
+
+    def test_assigned_to_queryset_limited_to_requesters_chapter(self):
+        other_chapter, _ = make_chapter_with_positions(
+            name="Sigma Nu", nm_invite_code="OTHNM002", active_invite_code="OTHACT02"
+        )
+        outsider = make_user(chapter=other_chapter)
+        form = SingleDueForm(self.requester)
+        queryset = form.fields["assigned_to"].queryset
+        self.assertIn(self.member, queryset)
+        self.assertNotIn(outsider, queryset)
+
+
+class BulkDueFormTests(TestCase):
+    def valid_data(self, **overrides):
+        data = {
+            "title": "Fall Dues",
+            "amount": "100.00",
+            "due_date": date.today(),
+            "target_group": "ALL",
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_data_is_valid(self):
+        form = BulkDueForm(data=self.valid_data())
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_pledge_class_without_semester_or_year_is_still_valid(self):
+        # No clean() override enforces pledge_semester/pledge_year when
+        # target_group=PLEDGE_CLASS is chosen — the form itself doesn't
+        # catch this, only ad hoc handling in the view. Pinning that the
+        # form alone considers this valid — see codebase-notes.md §5.
+        form = BulkDueForm(data=self.valid_data(target_group="PLEDGE_CLASS"))
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_invalid_target_group_choice_is_rejected(self):
+        form = BulkDueForm(data=self.valid_data(target_group="NOT_A_CHOICE"))
+        self.assertFalse(form.is_valid())
+        self.assertIn("target_group", form.errors)
+
+    def test_selected_user_ids_not_required(self):
+        form = BulkDueForm(data=self.valid_data())
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["selected_user_ids"], "")
+
+
+class BulkPointFormTests(TestCase):
+    def valid_data(self, **overrides):
+        data = {
+            "type": "AWARD",
+            "amount": 5,
+            "description": "Chapter event",
+            "date_for": date.today(),
+            "target_group": "ALL",
+        }
+        data.update(overrides)
+        return data
+
+    def test_award_type_forces_amount_positive(self):
+        form = BulkPointForm(data=self.valid_data(amount=5, type="AWARD"))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["amount"], 5)
+
+    def test_penalty_type_forces_amount_negative(self):
+        form = BulkPointForm(data=self.valid_data(amount=5, type="PENALTY"))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["amount"], -5)
+
+    def test_amount_must_be_at_least_one(self):
+        form = BulkPointForm(data=self.valid_data(amount=0))
+        self.assertFalse(form.is_valid())
+        self.assertIn("amount", form.errors)

--- a/palamedes/dashboard/tests/test_models.py
+++ b/palamedes/dashboard/tests/test_models.py
@@ -1,3 +1,181 @@
-from django.test import TestCase
+from datetime import date, datetime, timezone as dt_timezone
 
-# HousePoint / Due / Task / Announcement model tests — Phase 3.
+from django.test import TestCase
+from django.utils import timezone
+
+from dashboard.models import Announcement, Due, HousePoint, Task
+from palamedes.test_helpers import make_chapter_with_positions, make_user
+
+
+class HousePointModelTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.recipient = make_user(chapter=self.chapter, status="NM")
+        self.submitter = make_user(chapter=self.chapter, status="ACT")
+
+    def make_point(self, **overrides):
+        data = dict(
+            user=self.recipient,
+            chapter=self.chapter,
+            submitted_by=self.submitter,
+            amount=10,
+            description="Attended chapter meeting",
+        )
+        data.update(overrides)
+        return HousePoint.objects.create(**data)
+
+    def test_str_includes_username_amount_and_status_display(self):
+        point = self.make_point()
+        self.assertEqual(
+            str(point), f"{self.recipient.username} - 10 - Pending Approval"
+        )
+
+    def test_status_defaults_to_pending(self):
+        point = self.make_point()
+        self.assertEqual(point.status, "PENDING")
+
+    def test_date_for_defaults_to_today(self):
+        # default=timezone.now (a datetime-returning callable) on a
+        # DateField: the in-memory attribute holds the raw datetime until it
+        # round-trips through the DB, where DateField.to_python truncates it
+        # to a date on the way in. Reload to see the coerced value. Compare
+        # against timezone.now().date() rather than date.today() — settings
+        # pin TIME_ZONE='UTC', which can differ from local system time.
+        point = self.make_point()
+        point.refresh_from_db()
+        self.assertEqual(point.date_for, timezone.now().date())
+
+    def test_amount_can_be_negative_for_penalties(self):
+        point = self.make_point(amount=-5)
+        self.assertEqual(point.amount, -5)
+
+    def test_assigned_approver_optional(self):
+        point = self.make_point()
+        self.assertIsNone(point.assigned_approver)
+
+    def test_assigned_approver_set_null_when_approver_deleted(self):
+        approver = make_user(chapter=self.chapter, status="ACT")
+        point = self.make_point(assigned_approver=approver)
+        approver.delete()
+        point.refresh_from_db()
+        self.assertIsNone(point.assigned_approver)
+
+
+class DueModelTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter)
+
+    def test_str_includes_title_and_amount(self):
+        due = Due.objects.create(
+            title="Fall 2025 Dues", amount="150.00", due_date=date.today(),
+            assigned_to=self.user,
+        )
+        self.assertEqual(str(due), "Fall 2025 Dues - $150.00")
+
+    def test_is_paid_and_is_template_default_to_false(self):
+        due = Due.objects.create(
+            title="Fall 2025 Dues", amount="150.00", due_date=date.today(),
+            assigned_to=self.user,
+        )
+        self.assertFalse(due.is_paid)
+        self.assertFalse(due.is_template)
+
+    def test_assigned_to_optional_for_template_dues(self):
+        due = Due.objects.create(
+            title="Fall 2025 Dues", amount="150.00", due_date=date.today(),
+            is_template=True,
+        )
+        self.assertIsNone(due.assigned_to)
+
+    def test_due_deleted_when_assigned_user_deleted(self):
+        due = Due.objects.create(
+            title="Fall 2025 Dues", amount="150.00", due_date=date.today(),
+            assigned_to=self.user,
+        )
+        self.user.delete()
+        self.assertFalse(Due.objects.filter(pk=due.pk).exists())
+
+
+class TaskModelTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.assignee = make_user(chapter=self.chapter)
+        self.assigner = make_user(chapter=self.chapter, status="ACT")
+
+    def test_str_returns_title(self):
+        task = Task.objects.create(
+            assigned_to=self.assignee,
+            assigned_by=self.assigner,
+            title="Clean the house",
+            description="Weekly chore",
+            due_date=datetime(2026, 1, 1, tzinfo=dt_timezone.utc),
+        )
+        self.assertEqual(str(task), "Clean the house")
+
+    def test_completed_defaults_to_false(self):
+        task = Task.objects.create(
+            assigned_to=self.assignee,
+            assigned_by=self.assigner,
+            title="Clean the house",
+            description="Weekly chore",
+            due_date=datetime(2026, 1, 1, tzinfo=dt_timezone.utc),
+        )
+        self.assertFalse(task.completed)
+
+    def test_assigned_by_set_null_when_assigner_deleted(self):
+        task = Task.objects.create(
+            assigned_to=self.assignee,
+            assigned_by=self.assigner,
+            title="Clean the house",
+            description="Weekly chore",
+            due_date=datetime(2026, 1, 1, tzinfo=dt_timezone.utc),
+        )
+        self.assigner.delete()
+        task.refresh_from_db()
+        self.assertIsNone(task.assigned_by)
+
+    def test_task_deleted_when_assignee_deleted(self):
+        task = Task.objects.create(
+            assigned_to=self.assignee,
+            assigned_by=self.assigner,
+            title="Clean the house",
+            description="Weekly chore",
+            due_date=datetime(2026, 1, 1, tzinfo=dt_timezone.utc),
+        )
+        self.assignee.delete()
+        self.assertFalse(Task.objects.filter(pk=task.pk).exists())
+
+
+class AnnouncementModelTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.author = make_user(chapter=self.chapter, status="ACT")
+
+    def test_str_includes_title_and_chapter_name(self):
+        announcement = Announcement.objects.create(
+            chapter=self.chapter,
+            author=self.author,
+            title="Chapter Meeting",
+            content="Mandatory attendance.",
+        )
+        self.assertEqual(str(announcement), "Chapter Meeting - Theta Chi")
+
+    def test_date_posted_auto_populates(self):
+        announcement = Announcement.objects.create(
+            chapter=self.chapter,
+            author=self.author,
+            title="Chapter Meeting",
+            content="Mandatory attendance.",
+        )
+        self.assertIsNotNone(announcement.date_posted)
+
+    def test_announcement_deleted_when_chapter_deleted(self):
+        announcement = Announcement.objects.create(
+            chapter=self.chapter,
+            author=self.author,
+            title="Chapter Meeting",
+            content="Mandatory attendance.",
+        )
+        self.chapter.delete()
+        self.assertFalse(Announcement.objects.filter(pk=announcement.pk).exists())


### PR DESCRIPTION
## Summary
- Phase 3 of the multi-phase test suite effort (see docs/testing/progress.md for full status).
- Adds 38 tests covering dashboard's models (HousePoint, Due, Task, Announcement) and simple forms (NMPointRequestForm, ActivePointRequestForm, DirectPointAssignmentForm, SingleDueForm, BulkDueForm, BulkPointForm).
- Result: dashboard/models.py and dashboard/forms.py both at 100% line coverage (admin.py/urls.py already 100%, purely declarative). Full project suite: 104 tests passing. Project-wide coverage TOTAL now 60% (up from 52%).
- dashboard/views.py (401 statements, ~20 views) remains the only major gap -- that's Phases 4-6.
- No production code changes -- tests only. Pinned latent behavior this phase: BulkDueForm doesn't enforce pledge_semester/pledge_year when target_group=PLEDGE_CLASS is chosen (no clean() override, unlike BulkPointForm).
- Also documents a real Django/timezone gotcha hit while writing HousePoint model tests: date_for's default=timezone.now is a datetime-returning callable on a DateField, so the in-memory attribute holds a raw datetime until it round-trips through the DB, and date comparisons need to use timezone.now().date() rather than local date.today() since TIME_ZONE='UTC' in settings.

## Test plan
- [x] python manage.py test dashboard.tests.test_models dashboard.tests.test_forms -- 38 tests, all pass
- [x] python manage.py test (full suite) -- 104 tests, all pass, no regressions
- [x] coverage run manage.py test && coverage report -m -- dashboard/models.py and dashboard/forms.py at 100%

Generated with Claude Code
