### PR TITLE
Test suite Phase 4: dashboard read-only views

### DIFF
--- a/docs/testing/codebase-notes.md
+++ b/docs/testing/codebase-notes.md
@@ -563,13 +563,12 @@ straightforward form validation tests (required fields, valid email format).
 
 - **`unpaid_directory(request)`**: chapter members with at least one unpaid `Due`
   (`dues__is_paid=False`), `.distinct()`, annotated with `total_dues = Sum('dues__amount')`
-  — **note**: since the base filter already restricts to unpaid dues, but the `Sum`
-  annotation isn't filtered by `is_paid=False` specifically, if a member has some paid
-  and some unpaid dues, `total_dues` would sum **all** their dues rows (paid + unpaid)
-  because the annotation aggregates over the full joined `dues` relation shaped by the
-  `filter()`, not scoped separately — this is a subtle Django ORM gotcha (the filter()
-  call constrains the join used by the annotate) worth a dedicated test with a member
-  who has both paid and unpaid dues to confirm actual behavior. Optional `filter` GET
+  — **CORRECTED (was flagged as a suspected bug here, disproven by
+  `dashboard/tests/test_views_directory.py::UnpaidDirectoryViewTests::test_total_dues_annotation_sums_all_dues_not_just_unpaid`
+  in Phase 4)**: Django reuses the base filter's join for the `Sum` annotation, so
+  for a member with both a paid and an unpaid due, `total_dues` correctly reflects
+  only the unpaid amount — it does **not** sum paid+unpaid together. Not a bug;
+  don't "fix" this. Optional `filter` GET
   param (icontains on name/major/hometown) and `status` GET param (exact). Renders
   `dashboard/unpaid_directory.html`.
 

--- a/docs/testing/progress.md
+++ b/docs/testing/progress.md
@@ -150,10 +150,40 @@ Full suite: 104 tests, all passing.
 Branch: `tests/phase-3-dashboard-core`, 2 commits, not yet merged — pending
 user check-in.
 
-## Phase 4 — `dashboard` read-only/aggregation views — not started
+## Phase 4 — `dashboard` read-only/aggregation views — **DONE**
 
-Stub files ready: `test_views_dashboard.py`, `test_views_directory.py`,
-`test_views_points_hub.py`.
+41 tests added. `dashboard/views.py` up from 16% to **30%** line coverage
+(the 5 views this phase covers — `dashboard`, `directory`,
+`unpaid_directory`, `brother_profile`, `points_hub` — are now fully
+exercised; the remaining 70% is all Phase 5/6 territory). Full suite: 145
+tests, all passing.
+
+- `test_views_dashboard.py` (8 tests): login-required, approved-only
+  `total_points`, unpaid-only `dues_balance`, incomplete-only
+  `pending_tasks_count`, 5-most-recent chapter announcements (+ no-chapter
+  → `[]`), and pinning that `pending_points` is computed but never exposed
+  in context (dead code).
+- `test_views_directory.py` (15 tests): `directory` (chapter scoping, `q`
+  search across first/last/major/hometown, exact status filter),
+  `unpaid_directory` (only-unpaid-members listing, filter/status params),
+  `brother_profile` (404, cross-chapter denial, same-chapter render).
+  **Correction to codebase-notes.md**: the `unpaid_directory`
+  `Sum('dues__amount')` annotation was flagged as a suspected bug (summing
+  paid+unpaid together for a member with both). A dedicated test proved
+  this wrong — Django reuses the base filter's join for the annotation, so
+  `total_dues` correctly reflects only the unpaid amount. **Not a bug.**
+  Noted here so nobody "fixes" it later based on the stale note.
+- `test_views_points_hub.py` (18 tests): login-required, approved-only
+  `total_points`, `my_action_items` inbox (both OR branches), `exec_queue`
+  (empty without permission or with `position=None`, populated +
+  self-exclusion when permitted), leaderboard split (Coalesce keeps
+  zero-point members visible, correct ACT/NM split, descending order), and
+  the "mother logs" — digit-guarded recipient/approver filters, sort
+  allow-list (confirmed an injection-shaped sort value is safely ignored,
+  not just theoretically), NM/active log split.
+
+Branch: `tests/phase-4-dashboard-readviews`, 3 commits, not yet merged —
+pending user check-in.
 
 ## Phase 5 — `dashboard` workflow/mutation views — not started
 

--- a/palamedes/dashboard/tests/test_views_dashboard.py
+++ b/palamedes/dashboard/tests/test_views_dashboard.py
@@ -1,3 +1,98 @@
-from django.test import TestCase
+from datetime import date, datetime, timedelta, timezone as dt_timezone
 
-# dashboard() aggregation view tests — Phase 4.
+from django.test import TestCase
+from django.urls import reverse
+
+from dashboard.models import Announcement, Due, HousePoint, Task
+from palamedes.test_helpers import PLAIN_STATIC_STORAGE, make_chapter_with_positions, make_user
+
+
+@PLAIN_STATIC_STORAGE
+class DashboardViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        response = self.client.get(reverse("dashboard"))
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('dashboard')}"
+        )
+
+    def test_renders_dashboard_template(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dashboard/dashboard.html")
+
+    def test_total_points_sums_only_approved_points(self):
+        HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, amount=10, description="a",
+            status="APPROVED",
+        )
+        HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, amount=100, description="b",
+            status="PENDING",
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.context["total_points"], 10)
+
+    def test_pending_points_are_not_exposed_in_context(self):
+        # pending_points is computed in the view but never added to the
+        # context dict — dead code. Pinning that it stays absent, per
+        # codebase-notes.md §5.
+        HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, amount=100, description="b",
+            status="PENDING",
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertNotIn("pending_points", response.context)
+
+    def test_dues_balance_sums_unpaid_dues_only(self):
+        Due.objects.create(
+            title="Fall Dues", amount="50.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+        Due.objects.create(
+            title="Spring Dues", amount="75.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=True,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.context["dues_balance"], 50)
+
+    def test_pending_tasks_count_excludes_completed(self):
+        Task.objects.create(
+            assigned_to=self.user, title="Do a thing", description="x",
+            due_date=datetime(2026, 1, 1, tzinfo=dt_timezone.utc), completed=False,
+        )
+        Task.objects.create(
+            assigned_to=self.user, title="Already done", description="x",
+            due_date=datetime(2026, 1, 1, tzinfo=dt_timezone.utc), completed=True,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.context["pending_tasks_count"], 1)
+
+    def test_announcements_limited_to_five_most_recent_for_chapter(self):
+        base = datetime.now(dt_timezone.utc)
+        for i in range(7):
+            a = Announcement.objects.create(
+                chapter=self.chapter, author=self.user, title=f"Announcement {i}",
+                content="x",
+            )
+            a.date_posted = base + timedelta(minutes=i)
+            a.save()
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("dashboard"))
+        announcements = list(response.context["announcements"])
+        self.assertEqual(len(announcements), 5)
+        self.assertEqual(announcements[0].title, "Announcement 6")
+
+    def test_user_without_chapter_gets_empty_announcements(self):
+        chapterless_user = make_user(chapter=None)
+        self.client.force_login(chapterless_user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(list(response.context["announcements"]), [])

--- a/palamedes/dashboard/tests/test_views_directory.py
+++ b/palamedes/dashboard/tests/test_views_directory.py
@@ -1,3 +1,175 @@
-from django.test import TestCase
+from datetime import date
 
-# directory / unpaid_directory / brother_profile view tests — Phase 4.
+from django.test import TestCase
+from django.urls import reverse
+
+from dashboard.models import Due
+from palamedes.test_helpers import PLAIN_STATIC_STORAGE, make_chapter_with_positions, make_user
+
+
+@PLAIN_STATIC_STORAGE
+class DirectoryViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+        self.other_chapter, _ = make_chapter_with_positions(
+            name="Sigma Nu", nm_invite_code="OTHNM003", active_invite_code="OTHACT03"
+        )
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        response = self.client.get(reverse("brother_directory"))
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('brother_directory')}"
+        )
+
+    def test_lists_only_members_of_own_chapter(self):
+        member = make_user(chapter=self.chapter, first_name="Alice", last_name="Smith")
+        outsider = make_user(chapter=self.other_chapter, first_name="Bob", last_name="Jones")
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_directory"))
+        members = list(response.context["members"])
+        self.assertIn(member, members)
+        self.assertNotIn(outsider, members)
+
+    def test_query_filters_across_name_major_and_hometown(self):
+        make_user(chapter=self.chapter, first_name="Alice", last_name="Zephyr", major="Biology")
+        make_user(chapter=self.chapter, first_name="Bob", last_name="Smith", major="Chemistry")
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_directory"), {"q": "Biology"})
+        members = list(response.context["members"])
+        self.assertEqual(
+            {m.first_name for m in members}, {"Alice"}
+        )
+
+    def test_status_filter_is_exact(self):
+        make_user(chapter=self.chapter, status="NM", first_name="Newbie")
+        make_user(chapter=self.chapter, status="ACT", first_name="Actual")
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_directory"), {"status": "NM"})
+        members = list(response.context["members"])
+        self.assertTrue(all(m.status == "NM" for m in members))
+        self.assertIn("Newbie", [m.first_name for m in members])
+        self.assertNotIn("Actual", [m.first_name for m in members])
+
+    def test_search_query_defaults_to_empty_string(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_directory"))
+        self.assertEqual(response.context["search_query"], "")
+
+
+@PLAIN_STATIC_STORAGE
+class UnpaidDirectoryViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        response = self.client.get(reverse("unpaid_directory"))
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('unpaid_directory')}"
+        )
+
+    def test_only_members_with_an_unpaid_due_are_listed(self):
+        has_unpaid = make_user(chapter=self.chapter, first_name="Owes")
+        Due.objects.create(
+            title="Fall Dues", amount="50.00", due_date=date.today(),
+            assigned_to=has_unpaid, is_paid=False,
+        )
+        all_paid = make_user(chapter=self.chapter, first_name="Clear")
+        Due.objects.create(
+            title="Fall Dues", amount="50.00", due_date=date.today(),
+            assigned_to=all_paid, is_paid=True,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("unpaid_directory"))
+        members = list(response.context["members"])
+        self.assertIn(has_unpaid, members)
+        self.assertNotIn(all_paid, members)
+
+    def test_total_dues_annotation_sums_all_dues_not_just_unpaid(self):
+        # ORM gotcha documented in codebase-notes.md §5: the base filter
+        # (dues__is_paid=False) reuses its join for the Sum('dues__amount')
+        # annotation, so a member with BOTH a paid and an unpaid due gets
+        # total_dues = only the unpaid amount, not paid+unpaid combined —
+        # pinning the actual (not assumed) behavior here.
+        member = make_user(chapter=self.chapter, first_name="Mixed")
+        Due.objects.create(
+            title="Unpaid Due", amount="30.00", due_date=date.today(),
+            assigned_to=member, is_paid=False,
+        )
+        Due.objects.create(
+            title="Paid Due", amount="100.00", due_date=date.today(),
+            assigned_to=member, is_paid=True,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("unpaid_directory"))
+        members = {m.pk: m for m in response.context["members"]}
+        self.assertEqual(members[member.pk].total_dues, 30)
+
+    def test_filter_param_matches_name_major_hometown(self):
+        member = make_user(chapter=self.chapter, first_name="Findme", major="Astrophysics")
+        Due.objects.create(
+            title="Fall Dues", amount="50.00", due_date=date.today(),
+            assigned_to=member, is_paid=False,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("unpaid_directory"), {"filter": "Astro"})
+        members = list(response.context["members"])
+        self.assertIn(member, members)
+
+    def test_status_filter_is_exact(self):
+        nm = make_user(chapter=self.chapter, status="NM", first_name="Newbie")
+        Due.objects.create(
+            title="Fall Dues", amount="50.00", due_date=date.today(),
+            assigned_to=nm, is_paid=False,
+        )
+        act = make_user(chapter=self.chapter, status="ACT", first_name="Actual")
+        Due.objects.create(
+            title="Fall Dues", amount="50.00", due_date=date.today(),
+            assigned_to=act, is_paid=False,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("unpaid_directory"), {"status": "NM"})
+        members = list(response.context["members"])
+        self.assertIn(nm, members)
+        self.assertNotIn(act, members)
+
+    def test_search_query_defaults_to_empty_string(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("unpaid_directory"))
+        self.assertEqual(response.context["search_query"], "")
+
+
+@PLAIN_STATIC_STORAGE
+class BrotherProfileViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+        self.other_chapter, _ = make_chapter_with_positions(
+            name="Sigma Nu", nm_invite_code="OTHNM004", active_invite_code="OTHACT04"
+        )
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        brother = make_user(chapter=self.chapter)
+        url = reverse("brother_profile", kwargs={"pk": brother.pk})
+        response = self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_nonexistent_pk_returns_404(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_profile", kwargs={"pk": 999999}))
+        self.assertEqual(response.status_code, 404)
+
+    def test_same_chapter_profile_renders(self):
+        brother = make_user(chapter=self.chapter, first_name="Sam")
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_profile", kwargs={"pk": brother.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dashboard/brother_profile.html")
+        self.assertEqual(response.context["brother"], brother)
+
+    def test_cross_chapter_profile_is_denied(self):
+        outsider = make_user(chapter=self.other_chapter, first_name="Outsider")
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("brother_profile", kwargs={"pk": outsider.pk}))
+        self.assertRedirects(response, reverse("dashboard"))

--- a/palamedes/dashboard/tests/test_views_points_hub.py
+++ b/palamedes/dashboard/tests/test_views_points_hub.py
@@ -1,3 +1,227 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# points_hub() aggregation/leaderboard/mother-log-filter tests — Phase 4.
+from dashboard.models import HousePoint
+from palamedes.test_helpers import PLAIN_STATIC_STORAGE, make_chapter_with_positions, make_user
+
+
+@PLAIN_STATIC_STORAGE
+class PointsHubViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        response = self.client.get(reverse("points_hub"))
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('points_hub')}"
+        )
+
+    def test_total_points_sums_only_approved_points(self):
+        HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, amount=15, description="a",
+            status="APPROVED",
+        )
+        HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, amount=99, description="b",
+            status="PENDING",
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("points_hub"))
+        self.assertEqual(response.context["total_points"], 15)
+
+
+class ActionItemsTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+        self.other = make_user(chapter=self.chapter, status="ACT")
+        self.client.force_login(self.user)
+
+    def _get(self):
+        return self.client.get(reverse("points_hub"))
+
+    def test_includes_points_awaiting_my_approval(self):
+        point = HousePoint.objects.create(
+            user=self.other, chapter=self.chapter, submitted_by=self.other,
+            assigned_approver=self.user, amount=5, description="x", status="PENDING",
+        )
+        response = self._get()
+        self.assertIn(point, list(response.context["my_action_items"]))
+
+    def test_includes_my_countered_submissions(self):
+        point = HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, submitted_by=self.user,
+            amount=5, description="x", status="COUNTERED",
+        )
+        response = self._get()
+        self.assertIn(point, list(response.context["my_action_items"]))
+
+    def test_excludes_unrelated_points(self):
+        point = HousePoint.objects.create(
+            user=self.other, chapter=self.chapter, submitted_by=self.other,
+            amount=5, description="x", status="PENDING",
+        )
+        response = self._get()
+        self.assertNotIn(point, list(response.context["my_action_items"]))
+
+
+class ExecQueueTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.submitter = make_user(chapter=self.chapter, status="ACT")
+
+    def test_empty_without_can_manage_points(self):
+        limited = make_user(
+            chapter=self.chapter, status="ACT", position=self.positions["Treasurer"]
+        )
+        HousePoint.objects.create(
+            user=self.submitter, chapter=self.chapter, submitted_by=self.submitter,
+            amount=5, description="x", status="PENDING",
+        )
+        self.client.force_login(limited)
+        response = self.client.get(reverse("points_hub"))
+        self.assertEqual(list(response.context["exec_queue"]), [])
+
+    def test_populated_with_can_manage_points_excluding_self_submitted(self):
+        manager = make_user(
+            chapter=self.chapter, status="ACT", position=self.positions["President"]
+        )
+        other_pending = HousePoint.objects.create(
+            user=self.submitter, chapter=self.chapter, submitted_by=self.submitter,
+            amount=5, description="x", status="PENDING",
+        )
+        self_submitted = HousePoint.objects.create(
+            user=manager, chapter=self.chapter, submitted_by=manager,
+            amount=5, description="x", status="PENDING",
+        )
+        self.client.force_login(manager)
+        response = self.client.get(reverse("points_hub"))
+        queue = list(response.context["exec_queue"])
+        self.assertIn(other_pending, queue)
+        self.assertNotIn(self_submitted, queue)
+
+    def test_empty_when_position_is_none(self):
+        positionless = make_user(chapter=self.chapter, status="ACT", position=None)
+        self.client.force_login(positionless)
+        response = self.client.get(reverse("points_hub"))
+        self.assertEqual(list(response.context["exec_queue"]), [])
+
+
+class LeaderboardTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+        self.client.force_login(self.user)
+
+    def test_zero_point_members_are_included_via_coalesce(self):
+        zero_point_active = make_user(chapter=self.chapter, status="ACT")
+        response = self.client.get(reverse("points_hub"))
+        active_board = {u.pk: u for u in response.context["active_leaderboard"]}
+        self.assertIn(zero_point_active.pk, active_board)
+        self.assertEqual(active_board[zero_point_active.pk].total_points_val, 0)
+
+    def test_active_and_nm_split_correctly(self):
+        active_member = make_user(chapter=self.chapter, status="ACT")
+        nm_member = make_user(chapter=self.chapter, status="NM")
+        response = self.client.get(reverse("points_hub"))
+        active_ids = {u.pk for u in response.context["active_leaderboard"]}
+        nm_ids = {u.pk for u in response.context["nm_leaderboard"]}
+        self.assertIn(active_member.pk, active_ids)
+        self.assertNotIn(active_member.pk, nm_ids)
+        self.assertIn(nm_member.pk, nm_ids)
+        self.assertNotIn(nm_member.pk, active_ids)
+
+    def test_ordered_descending_by_total_points(self):
+        low = make_user(chapter=self.chapter, status="ACT")
+        high = make_user(chapter=self.chapter, status="ACT")
+        HousePoint.objects.create(
+            user=low, chapter=self.chapter, amount=5, description="x", status="APPROVED"
+        )
+        HousePoint.objects.create(
+            user=high, chapter=self.chapter, amount=50, description="x", status="APPROVED"
+        )
+        response = self.client.get(reverse("points_hub"))
+        active_board = list(response.context["active_leaderboard"])
+        high_index = next(i for i, u in enumerate(active_board) if u.pk == high.pk)
+        low_index = next(i for i, u in enumerate(active_board) if u.pk == low.pk)
+        self.assertLess(high_index, low_index)
+
+
+class MotherLogsTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter, status="ACT")
+        self.recipient = make_user(chapter=self.chapter, status="ACT")
+        self.approver = make_user(chapter=self.chapter, status="ACT")
+        self.point = HousePoint.objects.create(
+            user=self.recipient, chapter=self.chapter, submitted_by=self.user,
+            assigned_approver=self.approver, amount=5, description="x",
+            status="APPROVED",
+        )
+        self.client.force_login(self.user)
+
+    def test_recipient_filter_applies_when_digit(self):
+        other_point = HousePoint.objects.create(
+            user=self.user, chapter=self.chapter, submitted_by=self.user,
+            amount=1, description="y", status="APPROVED",
+        )
+        response = self.client.get(
+            reverse("points_hub"), {"recipient": str(self.recipient.pk)}
+        )
+        active_logs = list(response.context["active_logs"])
+        self.assertIn(self.point, active_logs)
+        self.assertNotIn(other_point, active_logs)
+        self.assertEqual(response.context["current_recipient"], self.recipient.pk)
+
+    def test_non_digit_recipient_is_ignored(self):
+        response = self.client.get(reverse("points_hub"), {"recipient": "not-a-number"})
+        self.assertIsNone(response.context["current_recipient"])
+        active_logs = list(response.context["active_logs"])
+        self.assertIn(self.point, active_logs)
+
+    def test_approver_filter_applies_when_digit(self):
+        response = self.client.get(
+            reverse("points_hub"), {"approver": str(self.approver.pk)}
+        )
+        self.assertEqual(response.context["current_approver"], self.approver.pk)
+        self.assertIn(self.point, list(response.context["active_logs"]))
+
+    def test_invalid_sort_falls_back_to_default(self):
+        response = self.client.get(reverse("points_hub"), {"sort": "'; DROP TABLE"})
+        self.assertEqual(response.context["current_sort"], "'; DROP TABLE")
+        # Falls back to -date_submitted ordering without raising.
+        self.assertEqual(response.status_code, 200)
+
+    def test_valid_sort_is_applied(self):
+        cheap = HousePoint.objects.create(
+            user=self.recipient, chapter=self.chapter, submitted_by=self.user,
+            amount=1, description="cheap", status="APPROVED",
+        )
+        response = self.client.get(reverse("points_hub"), {"sort": "amount"})
+        self.assertEqual(response.context["current_sort"], "amount")
+        active_logs = list(response.context["active_logs"])
+        cheap_index = next(i for i, p in enumerate(active_logs) if p.pk == cheap.pk)
+        expensive_index = next(i for i, p in enumerate(active_logs) if p.pk == self.point.pk)
+        self.assertLess(cheap_index, expensive_index)
+
+    def test_nm_logs_and_active_logs_split_by_recipient_status(self):
+        nm_recipient = make_user(chapter=self.chapter, status="NM")
+        nm_point = HousePoint.objects.create(
+            user=nm_recipient, chapter=self.chapter, submitted_by=self.user,
+            amount=3, description="nm point", status="APPROVED",
+        )
+        response = self.client.get(reverse("points_hub"))
+        self.assertIn(nm_point, list(response.context["nm_logs"]))
+        self.assertNotIn(nm_point, list(response.context["active_logs"]))
+        self.assertIn(self.point, list(response.context["active_logs"]))
+        self.assertNotIn(self.point, list(response.context["nm_logs"]))
+
+    def test_chapter_members_and_approvers_list(self):
+        nm_member = make_user(chapter=self.chapter, status="NM")
+        response = self.client.get(reverse("points_hub"))
+        chapter_members = list(response.context["chapter_members"])
+        approvers_list = list(response.context["approvers_list"])
+        self.assertIn(self.recipient, chapter_members)
+        self.assertIn(nm_member, chapter_members)
+        self.assertNotIn(nm_member, approvers_list)


### PR DESCRIPTION
## Summary
- Phase 4 of the multi-phase test suite effort (see docs/testing/progress.md for full status).
- Adds 41 tests covering dashboard's read-only/aggregation views: dashboard(), directory, unpaid_directory, brother_profile, and points_hub.
- Result: dashboard/views.py up from 16% to 30% line coverage (the 5 views this phase targets are now fully exercised). Full project suite: 145 tests passing. Project-wide coverage TOTAL now 67% (up from 60%).
- Corrects a suspected bug from the Phase-0 codebase recon: unpaid_directory's Sum('dues__amount') annotation was flagged as possibly summing paid+unpaid dues together for a member with both. A dedicated test disproved this -- Django reuses the base filter's join, so total_dues correctly reflects only unpaid dues. Updated both codebase-notes.md and progress.md so nobody "fixes" correct behavior later.
- No production code changes -- tests only. Pinned latent behavior this phase: dashboard()'s pending_points variable is computed but never exposed in the template context (dead code).

## Test plan
- [x] python manage.py test dashboard.tests.test_views_dashboard dashboard.tests.test_views_directory dashboard.tests.test_views_points_hub -- 41 tests, all pass
- [x] python manage.py test (full suite) -- 145 tests, all pass, no regressions
- [x] coverage run manage.py test && coverage report -m -- dashboard/views.py at 30%, all 5 views this phase targets fully covered

Generated with Claude Code
