### PR TITLE
Test suite Phase 6: Stripe payment views + dues_member

### DIFF
--- a/docs/testing/codebase-notes.md
+++ b/docs/testing/codebase-notes.md
@@ -705,15 +705,28 @@ across almost every view with a mutation or permission denial. Tests can assert 
 `response.context['messages']` or by checking redirected-to page's rendered content,
 or directly inspect `list(get_messages(response.wsgi_request))`.
 
-### Known bugs / broken code paths (do not silently "fix" while writing tests — document via tests that pin current behavior, or flag explicitly if the task later asks for fixes)
+### Known bugs / broken code paths (do not silently "fix" while writing tests — document via tests that pin current behavior; a GitHub issue gets filed for each one confirmed by a passing test, per the user's standing instruction from Phase 6 onward)
 - `_helper_bulk_transaction` (`dashboard/views.py`) `PLEDGE_CLASS` branch:
   `members.get('pledge_semester')` and `members.filer(...)` — both invalid, will raise.
+  Confirmed + pinned in Phase 5. **[Issue #50](https://github.com/dannguyen111/palamedes/issues/50)**.
 - `dues_dashboard`, `manage_point_request` (`is_top2`), `mark_paid`: unguarded
   `request.user.position.<flag>` access — `AttributeError` when `position is None`.
-- `dashboard` view computes `pending_points` but never puts it in the template context (dead code, harmless).
+  Confirmed + pinned in Phase 5. **[Issue #49](https://github.com/dannguyen111/palamedes/issues/49)**.
+- `dashboard` view computes `pending_points` but never puts it in the template context (dead code, harmless — no issue filed, not an actual bug).
 - `payment_success` single-payment branch has no `assigned_to`/ownership filter on the `Due` lookup.
-- `make_payment_treasurer` has no permission check at all (any logged-in user can view any due's "mark paid" screen, though it appears to be read-only/display-only based on the view code — confirm template doesn't expose a mutation form without a corresponding permission-checked POST handler).
+  Confirmed + pinned in Phase 6. **[Issue #54](https://github.com/dannguyen111/palamedes/issues/54)**.
+- `make_payment_treasurer` has no permission check at all (any logged-in user can view any due's "mark paid" screen).
+  Confirmed + pinned in Phase 6. **[Issue #52](https://github.com/dannguyen111/palamedes/issues/52)**.
 - `dues_member` has no `@login_required` and no chapter scoping.
+  Confirmed + pinned in Phase 6. **[Issue #51](https://github.com/dannguyen111/palamedes/issues/51)**.
+- `process_payment`'s `due_amount` parsing (`int(float(request.POST.get('due_amount')) * 100)`)
+  sits outside the try/except wrapping the Stripe call, so a missing/non-numeric amount
+  crashes uncaught instead of getting the graceful JSON 500 the Stripe call itself gets.
+  Confirmed + pinned in Phase 6. **[Issue #53](https://github.com/dannguyen111/palamedes/issues/53)**.
+- `create_bulk_checkout_session`/`process_payment` call `redirect(url, code=303)`, but Django's
+  `redirect()` shortcut has no `code` kwarg — it's silently ignored, so the actual response is a
+  plain 302, not 303. Harmless in practice (redirecting to Stripe's hosted checkout is a GET
+  either way regardless of 302 vs 303) — no issue filed, cosmetic only.
 - Dead templates `inbox.html`, `ledger.html` with corresponding commented-out URL routes and no view functions — not testable/relevant.
 - `CustomUser.save()` PIL-based image-thumbnailing override is commented out (dead code) — don't test for thumbnailing.
 

--- a/docs/testing/progress.md
+++ b/docs/testing/progress.md
@@ -232,9 +232,55 @@ matters, don't just chase the coverage number.
 Branch: `tests/phase-5-dashboard-workflows`, 2 commits, not yet merged —
 pending user check-in.
 
-## Phase 6 — Stripe-integrated payment views — not started
+## Phase 6 — Stripe-integrated payment views — **DONE**
 
-Stub file ready: `test_views_payments.py`.
+32 tests added. `dashboard/views.py` up from 83% to **99%** line coverage — the
+only two lines left uncovered (287-288) are unreachable dead code inside the
+already-broken `PLEDGE_CLASS` branch (issue #50), past the line that always
+raises first. Full suite: **229 tests**, all passing. Project-wide `TOTAL`:
+**99%**.
+
+- `payment_page`: ownership 404 boundary.
+- `make_payment_treasurer`: pinned — **no permission check at all**.
+- `dues_member`: pinned — **no `@login_required`, no chapter scoping**, plus
+  ordering behavior.
+- `create_bulk_checkout_session` / `process_payment`: `stripe.checkout.Session.create`
+  mocked for success (redirect to session URL, correct line items/metadata,
+  ownership-filtered `due_ids`) and exception (JSON 500) paths. Also pinned:
+  the `if request.POST:` truthiness quirk (empty POST body silently treated
+  as non-POST), and `process_payment`'s `due_amount` parsing sitting outside
+  the try/except so it crashes uncaught on missing/non-numeric input.
+- `payment_success`: `stripe.checkout.Session.retrieve` mocked for
+  missing-session_id, retrieve-exception, bulk-payment (ownership-scoped),
+  single-payment (full/partial), and replay/idempotency
+  (`processed_sessions` in the Django session) paths. Pinned: the
+  single-payment branch's `Due` lookup has **no ownership filter**, unlike
+  every sibling payment view.
+
+**GitHub issues filed this phase** (per user request — bugs found while
+testing now get filed for a future fix-bugs pass, not just documented in
+these notes):
+- [#49](https://github.com/dannguyen111/palamedes/issues/49) — unguarded
+  `position` AttributeError in `dues_dashboard`/`manage_point_request`/`mark_paid`
+  (confirmed in Phase 5, filed retroactively at the start of this phase)
+- [#50](https://github.com/dannguyen111/palamedes/issues/50) — broken
+  `PLEDGE_CLASS` bulk-dues branch (confirmed in Phase 5, filed retroactively)
+- [#51](https://github.com/dannguyen111/palamedes/issues/51) — `dues_member`
+  has no auth/chapter-scoping
+- [#52](https://github.com/dannguyen111/palamedes/issues/52) —
+  `make_payment_treasurer` has no permission check
+- [#53](https://github.com/dannguyen111/palamedes/issues/53) —
+  `process_payment` crashes uncaught on bad `due_amount`
+- [#54](https://github.com/dannguyen111/palamedes/issues/54) —
+  `payment_success` single-payment branch has no ownership check
+
+**Going forward**: file a GitHub issue for every newly-confirmed bug (pinned
+by a passing test), the same way — see the issue bodies above for the
+template (Summary / Location / Impact / How this was found / Suggested fix,
+with a link to the pinning test).
+
+Branch: `tests/phase-6-dashboard-payments`, 1 commit, not yet merged —
+pending user check-in.
 
 ## Phase 7 — coverage gap-filling & wrap-up — not started
 
@@ -244,17 +290,18 @@ tightly coupled to that app).
 
 ---
 
-## Current coverage snapshot (after Phase 5)
+## Current coverage snapshot (after Phase 6)
 
-`coverage run manage.py test && coverage report -m` (full suite, 197 tests):
+`coverage run manage.py test && coverage report -m` (full suite, 229 tests):
 
 - `homepage/`, `users/`: **100%** everywhere (unchanged since Phase 2).
 - `dashboard/`: `models.py`, `forms.py`, `admin.py`, `urls.py` all **100%**.
-  `views.py` at **83%** — every view except the Stripe-integrated payment
-  ones (`payment_page`, `create_bulk_checkout_session`, `process_payment`,
-  `payment_success`, `make_payment_treasurer`) is fully covered. That's all
-  that's left, and it's exactly Phase 6.
-- `palamedes/settings.py` at 96% (AWS S3 branch, out of scope), `urls.py` at
-  89% (DEBUG-only static route).
-- Project `TOTAL`: **92%** (up from 67% after Phase 4) — already past the
-  80% target from the original ask. Phase 6 should push this to ~98-100%.
+  `views.py` at **99%** (2 unreachable lines inside the known-broken
+  `PLEDGE_CLASS` branch, issue #50).
+- `palamedes/settings.py` at 96% (AWS S3 branch, only exercised when
+  `AWS_ACCESS_KEY_ID` is set — genuinely out of scope for a local/CI test
+  run), `urls.py` at 89% (DEBUG-only static media route).
+- Project `TOTAL`: **99%** (up from 92% after Phase 5). Only Phase 7 remains
+  — admin.py smoke tests for users/dashboard (already at 100% coverage
+  incidentally, since they're purely declarative, but not yet deliberately
+  tested) and a final sweep for anything missed.

--- a/palamedes/dashboard/tests/test_views_payments.py
+++ b/palamedes/dashboard/tests/test_views_payments.py
@@ -1,5 +1,442 @@
-from django.test import TestCase
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
 
-# payment_page / create_bulk_checkout_session / process_payment /
-# payment_success / make_payment_treasurer view tests (Stripe mocked) —
-# Phase 6.
+from django.test import TestCase
+from django.urls import reverse
+
+from dashboard.models import Due
+from palamedes.test_helpers import PLAIN_STATIC_STORAGE, make_chapter_with_positions, make_user
+
+
+@PLAIN_STATIC_STORAGE
+class PaymentPageViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter)
+        self.due = Due.objects.create(
+            title="Fall Dues", amount="100.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        url = reverse("payment_page", kwargs={"pk": self.due.pk})
+        response = self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_owner_can_view_payment_page(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("payment_page", kwargs={"pk": self.due.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dashboard/payment_page.html")
+        self.assertEqual(response.context["due"], self.due)
+
+    def test_non_owner_gets_404(self):
+        other_user = make_user(chapter=self.chapter)
+        self.client.force_login(other_user)
+        response = self.client.get(reverse("payment_page", kwargs={"pk": self.due.pk}))
+        self.assertEqual(response.status_code, 404)
+
+
+class MakePaymentTreasurerViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.owner = make_user(chapter=self.chapter)
+        self.due = Due.objects.create(
+            title="Fall Dues", amount="100.00", due_date=date.today(),
+            assigned_to=self.owner, is_paid=False,
+        )
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        url = reverse("make_mark_paid", kwargs={"pk": self.due.pk})
+        response = self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_nonexistent_pk_returns_404(self):
+        self.owner_login()
+        response = self.client.get(reverse("make_mark_paid", kwargs={"pk": 999999}))
+        self.assertEqual(response.status_code, 404)
+
+    def owner_login(self):
+        self.client.force_login(self.owner)
+
+    def test_any_logged_in_user_can_view_any_due_no_permission_gate(self):
+        # No permission check at all here — unlike mark_paid (which at
+        # least checks can_manage_finance, even if unguarded against
+        # position=None). Any authenticated user, including one from a
+        # completely different chapter with no relation to this due, can
+        # view it. Pinning the gap; see codebase-notes.md §6.
+        other_chapter, _ = make_chapter_with_positions(
+            name="Sigma Nu", nm_invite_code="OTHNM005", active_invite_code="OTHACT05"
+        )
+        stranger = make_user(chapter=other_chapter)
+        self.client.force_login(stranger)
+        response = self.client.get(reverse("make_mark_paid", kwargs={"pk": self.due.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["due"], self.due)
+
+
+class DuesMemberViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.member = make_user(chapter=self.chapter)
+
+    def test_anonymous_user_can_view_without_logging_in(self):
+        # dues_member (URL name brothers_due) is the one dashboard view with
+        # no @login_required — anonymous access is currently possible.
+        # Pinning the gap; see codebase-notes.md §6.
+        response = self.client.get(
+            reverse("brothers_due", kwargs={"pk": self.member.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dashboard/member_dues_details.html")
+
+    def test_cross_chapter_user_can_view_with_no_scoping(self):
+        other_chapter, _ = make_chapter_with_positions(
+            name="Sigma Nu", nm_invite_code="OTHNM006", active_invite_code="OTHACT06"
+        )
+        outsider = make_user(chapter=other_chapter)
+        self.client.force_login(outsider)
+        response = self.client.get(
+            reverse("brothers_due", kwargs={"pk": self.member.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["brother"], self.member)
+
+    def test_nonexistent_pk_returns_404(self):
+        response = self.client.get(reverse("brothers_due", kwargs={"pk": 999999}))
+        self.assertEqual(response.status_code, 404)
+
+    def test_dues_ordered_unpaid_first_then_by_due_date(self):
+        later_unpaid = Due.objects.create(
+            title="Later", amount="10.00", due_date=date(2026, 6, 1),
+            assigned_to=self.member, is_paid=False,
+        )
+        earlier_unpaid = Due.objects.create(
+            title="Earlier", amount="10.00", due_date=date(2026, 1, 1),
+            assigned_to=self.member, is_paid=False,
+        )
+        paid = Due.objects.create(
+            title="Paid", amount="10.00", due_date=date(2025, 1, 1),
+            assigned_to=self.member, is_paid=True,
+        )
+        response = self.client.get(
+            reverse("brothers_due", kwargs={"pk": self.member.pk})
+        )
+        dues = list(response.context["dues"])
+        self.assertEqual(dues, [earlier_unpaid, later_unpaid, paid])
+
+
+class CreateBulkCheckoutSessionViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter)
+        self.due1 = Due.objects.create(
+            title="Fall Dues", amount="100.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+        self.due2 = Due.objects.create(
+            title="Spring Dues", amount="50.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        url = reverse("create_bulk_checkout_session")
+        response = self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_get_request_redirects_to_dashboard(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("create_bulk_checkout_session"))
+        self.assertRedirects(response, reverse("dashboard"))
+
+    def test_empty_post_body_is_treated_as_not_post_and_redirects_to_dashboard(self):
+        # `if request.POST:` is a truthiness check on the QueryDict, not
+        # `request.method == 'POST'` — an empty POST body is falsy and this
+        # branch is skipped entirely, even though it genuinely was a POST
+        # request. See codebase-notes.md §5.
+        self.client.force_login(self.user)
+        response = self.client.post(reverse("create_bulk_checkout_session"), data={})
+        self.assertRedirects(response, reverse("dashboard"))
+
+    @patch("dashboard.views.stripe.checkout.Session.create")
+    def test_valid_post_creates_session_for_owned_dues_and_redirects(self, mock_create):
+        mock_create.return_value = MagicMock(url="https://stripe.example/checkout/sess_123")
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("create_bulk_checkout_session"),
+            data={"due_ids": [str(self.due1.pk), str(self.due2.pk)]},
+        )
+        # The view calls redirect(url, code=303), but Django's redirect()
+        # shortcut has no `code` kwarg (only `permanent`) — it's silently
+        # ignored, so the actual response is a plain 302, not 303. Harmless
+        # in practice (redirecting to Stripe's hosted checkout is a GET
+        # either way), but the intent in the code doesn't match reality.
+        self.assertRedirects(
+            response, "https://stripe.example/checkout/sess_123", fetch_redirect_response=False
+        )
+        self.assertEqual(response.status_code, 302)
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        self.assertEqual(len(call_kwargs["line_items"]), 2)
+        self.assertEqual(call_kwargs["metadata"]["payment_type"], "bulk_payment")
+        due_ids_str = call_kwargs["metadata"]["due_ids_str"]
+        self.assertEqual(
+            set(due_ids_str.split(",")), {str(self.due1.pk), str(self.due2.pk)}
+        )
+
+    @patch("dashboard.views.stripe.checkout.Session.create")
+    def test_other_users_due_ids_are_silently_excluded(self, mock_create):
+        mock_create.return_value = MagicMock(url="https://stripe.example/checkout/sess_123")
+        other_user = make_user(chapter=self.chapter)
+        others_due = Due.objects.create(
+            title="Not Yours", amount="20.00", due_date=date.today(),
+            assigned_to=other_user, is_paid=False,
+        )
+        self.client.force_login(self.user)
+        self.client.post(
+            reverse("create_bulk_checkout_session"),
+            data={"due_ids": [str(self.due1.pk), str(others_due.pk)]},
+        )
+        call_kwargs = mock_create.call_args.kwargs
+        due_ids_str = call_kwargs["metadata"]["due_ids_str"]
+        self.assertNotIn(str(others_due.pk), due_ids_str.split(","))
+
+    @patch("dashboard.views.stripe.checkout.Session.create")
+    def test_stripe_exception_returns_json_500(self, mock_create):
+        mock_create.side_effect = Exception("stripe is down")
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("create_bulk_checkout_session"),
+            data={"due_ids": [str(self.due1.pk)]},
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json()["error"], "stripe is down")
+
+
+class ProcessPaymentViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter)
+        self.due = Due.objects.create(
+            title="Fall Dues", amount="100.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        url = reverse("create_checkout_session", kwargs={"pk": self.due.pk})
+        response = self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_non_owner_gets_404(self):
+        other_user = make_user(chapter=self.chapter)
+        self.client.force_login(other_user)
+        response = self.client.post(
+            reverse("create_checkout_session", kwargs={"pk": self.due.pk}),
+            data={"due_amount": "100"},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_request_redirects_to_dashboard(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse("create_checkout_session", kwargs={"pk": self.due.pk})
+        )
+        self.assertRedirects(response, reverse("dashboard"))
+
+    def test_missing_due_amount_raises_uncaught_exception(self):
+        # amount = int(float(request.POST.get('due_amount')) * 100) sits
+        # OUTSIDE the try/except that wraps the Stripe call, so a missing
+        # or non-numeric due_amount crashes with an uncaught
+        # TypeError/ValueError instead of the graceful JSON 500 the Stripe
+        # call itself gets. See codebase-notes.md §5. Note the POST body
+        # can't be completely empty here — `if request.POST:` is the same
+        # truthiness check as create_bulk_checkout_session (see that test
+        # class), so an empty body skips this branch and just redirects; a
+        # non-empty body missing only the due_amount key is what reaches
+        # the crash.
+        self.client.force_login(self.user)
+        with self.assertRaises(TypeError):
+            self.client.post(
+                reverse("create_checkout_session", kwargs={"pk": self.due.pk}),
+                data={"unrelated_field": "x"},
+            )
+
+    def test_non_numeric_due_amount_raises_uncaught_exception(self):
+        self.client.force_login(self.user)
+        with self.assertRaises(ValueError):
+            self.client.post(
+                reverse("create_checkout_session", kwargs={"pk": self.due.pk}),
+                data={"due_amount": "not-a-number"},
+            )
+
+    @patch("dashboard.views.stripe.checkout.Session.create")
+    def test_valid_post_creates_session_and_redirects(self, mock_create):
+        mock_create.return_value = MagicMock(url="https://stripe.example/checkout/sess_456")
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("create_checkout_session", kwargs={"pk": self.due.pk}),
+            data={"due_amount": "100"},
+        )
+        self.assertRedirects(
+            response, "https://stripe.example/checkout/sess_456", fetch_redirect_response=False
+        )
+        call_kwargs = mock_create.call_args.kwargs
+        self.assertEqual(call_kwargs["metadata"]["due_id"], self.due.pk)
+        self.assertEqual(call_kwargs["metadata"]["payment_type"], "single")
+
+    @patch("dashboard.views.stripe.checkout.Session.create")
+    def test_stripe_exception_returns_json_500(self, mock_create):
+        mock_create.side_effect = Exception("stripe is down")
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("create_checkout_session", kwargs={"pk": self.due.pk}),
+            data={"due_amount": "100"},
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json()["error"], "stripe is down")
+
+
+class PaymentSuccessViewTests(TestCase):
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.user = make_user(chapter=self.chapter)
+        self.due = Due.objects.create(
+            title="Fall Dues", amount="100.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+        self.client.force_login(self.user)
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        url = reverse("payment_success")
+        response = self.client.logout() or self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_missing_session_id_redirects_to_dashboard_with_error(self):
+        response = self.client.get(reverse("payment_success"), follow=True)
+        self.assertRedirects(response, reverse("dashboard"))
+        messages = list(response.context["messages"])
+        self.assertTrue(any("Missing payment session" in str(m) for m in messages))
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_stripe_retrieve_exception_redirects_to_dashboard_with_error(self, mock_retrieve):
+        mock_retrieve.side_effect = Exception("stripe is down")
+        response = self.client.get(
+            reverse("payment_success"), {"session_id": "sess_bad"}, follow=True
+        )
+        self.assertRedirects(response, reverse("dashboard"))
+        messages = list(response.context["messages"])
+        self.assertTrue(any("problem verifying your payment" in str(m) for m in messages))
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_bulk_payment_marks_owned_dues_paid_and_zeroed(self, mock_retrieve):
+        due2 = Due.objects.create(
+            title="Spring Dues", amount="50.00", due_date=date.today(),
+            assigned_to=self.user, is_paid=False,
+        )
+        mock_retrieve.return_value = MagicMock(
+            metadata={
+                "payment_type": "bulk_payment",
+                "due_ids_str": f"{self.due.pk},{due2.pk}",
+            }
+        )
+        response = self.client.get(
+            reverse("payment_success"), {"session_id": "sess_bulk"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dashboard/successful_payment.html")
+        self.due.refresh_from_db()
+        due2.refresh_from_db()
+        self.assertTrue(self.due.is_paid)
+        self.assertEqual(self.due.amount, 0)
+        self.assertTrue(due2.is_paid)
+        self.assertEqual(due2.amount, 0)
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_bulk_payment_only_affects_dues_owned_by_requesting_user(self, mock_retrieve):
+        other_user = make_user(chapter=self.chapter)
+        others_due = Due.objects.create(
+            title="Not Yours", amount="20.00", due_date=date.today(),
+            assigned_to=other_user, is_paid=False,
+        )
+        mock_retrieve.return_value = MagicMock(
+            metadata={
+                "payment_type": "bulk_payment",
+                "due_ids_str": f"{self.due.pk},{others_due.pk}",
+            }
+        )
+        self.client.get(reverse("payment_success"), {"session_id": "sess_bulk2"})
+        others_due.refresh_from_db()
+        self.assertFalse(others_due.is_paid)
+        self.assertEqual(others_due.amount, Decimal("20.00"))
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_single_payment_full_amount_marks_due_paid(self, mock_retrieve):
+        mock_retrieve.return_value = MagicMock(
+            metadata={"payment_type": "single", "due_id": str(self.due.pk)},
+            amount_total=10000,  # $100.00 in cents
+        )
+        response = self.client.get(
+            reverse("payment_success"), {"session_id": "sess_full"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.due.refresh_from_db()
+        self.assertTrue(self.due.is_paid)
+        self.assertEqual(self.due.amount, 0)
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_single_payment_partial_amount_leaves_remaining_balance(self, mock_retrieve):
+        mock_retrieve.return_value = MagicMock(
+            metadata={"payment_type": "single", "due_id": str(self.due.pk)},
+            amount_total=4000,  # $40.00 in cents
+        )
+        response = self.client.get(
+            reverse("payment_success"), {"session_id": "sess_partial"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.due.refresh_from_db()
+        self.assertFalse(self.due.is_paid)
+        self.assertEqual(self.due.amount, Decimal("60.00"))
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_replayed_session_id_does_not_mutate_due_again(self, mock_retrieve):
+        mock_retrieve.return_value = MagicMock(
+            metadata={"payment_type": "single", "due_id": str(self.due.pk)},
+            amount_total=4000,
+        )
+        self.client.get(reverse("payment_success"), {"session_id": "sess_replay"})
+        self.due.refresh_from_db()
+        self.assertEqual(self.due.amount, Decimal("60.00"))
+
+        # Second hit with the same session_id should be a no-op (idempotency
+        # guard via request.session['processed_sessions']).
+        response = self.client.get(
+            reverse("payment_success"), {"session_id": "sess_replay"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.due.refresh_from_db()
+        self.assertEqual(self.due.amount, Decimal("60.00"))
+
+    @patch("dashboard.views.stripe.checkout.Session.retrieve")
+    def test_single_payment_has_no_ownership_check_on_the_due(self, mock_retrieve):
+        # get_object_or_404(Due, pk=due_id) here has no assigned_to filter,
+        # unlike payment_page/process_payment which both scope by
+        # assigned_to=request.user. Any logged-in user who obtains/guesses a
+        # valid session_id referencing someone else's due can mark it paid
+        # through this view. Pinning the gap; see codebase-notes.md §6.
+        other_user = make_user(chapter=self.chapter)
+        others_due = Due.objects.create(
+            title="Not Yours", amount="100.00", due_date=date.today(),
+            assigned_to=other_user, is_paid=False,
+        )
+        mock_retrieve.return_value = MagicMock(
+            metadata={"payment_type": "single", "due_id": str(others_due.pk)},
+            amount_total=10000,
+        )
+        # self.user (not others_due's owner) hits payment_success.
+        response = self.client.get(
+            reverse("payment_success"), {"session_id": "sess_cross_user"}
+        )
+        self.assertEqual(response.status_code, 200)
+        others_due.refresh_from_db()
+        self.assertTrue(others_due.is_paid)


### PR DESCRIPTION
## Summary
- Phase 6 of the multi-phase test suite effort (see docs/testing/progress.md for full status) -- the final view-coverage phase, covering the Stripe-integrated payment views plus dues_member.
- Adds 32 tests: payment_page, make_payment_treasurer, dues_member, create_bulk_checkout_session, process_payment (all with stripe.checkout.Session.create/.retrieve mocked), and payment_success across all its branches (missing session_id, retrieve exception, bulk payment, single payment full/partial, replay idempotency).
- Result: dashboard/views.py up from 83% to 99% line coverage -- the only 2 uncovered lines are unreachable dead code inside the already-known-broken PLEDGE_CLASS branch (issue #50). Full project suite: 229 tests passing. Project-wide coverage TOTAL now 99%.
- No production code changes -- tests only, per the earlier bug-handling decision (pin current behavior, don't fix).

## GitHub issues filed this phase
Per a new standing instruction: file an issue for every bug confirmed by a passing test, not just document it in notes. Filed 6 total this phase (2 retroactively for Phase 5 findings, 4 new):
- #49 -- unguarded `position` AttributeError in dues_dashboard/manage_point_request/mark_paid (Phase 5 finding, filed retroactively)
- #50 -- broken PLEDGE_CLASS bulk-dues branch (Phase 5 finding, filed retroactively)
- #51 -- dues_member has no login requirement or chapter scoping
- #52 -- make_payment_treasurer has no permission check at all
- #53 -- process_payment crashes uncaught on missing/non-numeric due_amount (parsing sits outside the try/except that wraps the Stripe call)
- #54 -- payment_success's single-payment branch has no ownership check on the Due lookup, unlike every sibling payment view

## Test plan
- [x] python manage.py test dashboard.tests.test_views_payments -- 32 tests, all pass
- [x] python manage.py test (full suite) -- 229 tests, all pass, no regressions
- [x] coverage run manage.py test && coverage report -m -- dashboard/views.py at 99%, project TOTAL at 99%

Generated with Claude Code
