### PR TITLE
Phase 7: admin.py smoke tests + coverage wrap-up (final phase)

### DIFF
--- a/docs/testing/codebase-notes.md
+++ b/docs/testing/codebase-notes.md
@@ -70,6 +70,12 @@ contains `manage.py`) unless stated otherwise.
   local/CI test run (no AWS env vars) this branch is **not** exercised — image upload
   tests will use local `MEDIA_ROOT`, so tests writing `CustomUser.image` should clean up
   files or use Django's `override_settings(MEDIA_ROOT=tempdir)`.
+  **Correction (Phase 7):** this specific dev machine's `.env` *does* set real AWS
+  credentials, so on this machine it's actually the **opposite** branch (local
+  `MEDIA_URL`/`MEDIA_ROOT`, settings.py lines 175-176) that goes uncovered by
+  `coverage run manage.py test` — confirmed via `coverage report -m`. Either way
+  it's a module-level branch decided once by environment config at process start,
+  not a per-test-togglable path — not worth chasing for coverage.
 
 ## `palamedes/urls.py` (project-level URLs)
 

--- a/docs/testing/progress.md
+++ b/docs/testing/progress.md
@@ -282,26 +282,75 @@ with a link to the pinning test).
 Branch: `tests/phase-6-dashboard-payments`, 1 commit, not yet merged —
 pending user check-in.
 
-## Phase 7 — coverage gap-filling & wrap-up — not started
+## Phase 7 — coverage gap-filling & wrap-up — **DONE**
 
-Stub files ready: `users/tests/test_admin.py`, `dashboard/tests/test_admin.py`
-(homepage's admin action test is pulled forward into Phase 1 since it's small and
-tightly coupled to that app).
+19 tests added (10 in `users/tests/test_admin.py`, 9 in
+`dashboard/tests/test_admin.py`). Full suite: **248 tests**, all passing.
+Project-wide `TOTAL` unchanged at **99%** (these tests exercise lines that
+were already counted covered incidentally — `admin.py` files are purely
+declarative registrations — but now the coverage is deliberate, not
+accidental).
+
+- `users/tests/test_admin.py` (10 tests): `PositionAdmin` (changelist +
+  chapter filter, search, change view), `ChapterAdmin` (changelist, search,
+  add view, change view), `CustomUserAdmin` (changelist + chapter/status/
+  is_staff filters, add/change views render the extra "Fraternity Info"
+  fieldset). All driven through the real admin URLs against a logged-in
+  superuser, not just `admin.site._registry` assertions — this actually
+  exercises `list_display`, `list_filter`, `search_fields`, and the custom
+  `fieldsets`/`add_fieldsets` tuples against real rows.
+- `dashboard/tests/test_admin.py` (9 tests): `HousePointAdmin` (changelist +
+  status/chapter filters, search, change view), `DueAdmin` (changelist +
+  is_paid/is_template filters, change view), `TaskAdmin` (changelist +
+  completed/assigned_to filters, change view), `AnnouncementAdmin`
+  (changelist + chapter filter, change view).
+- **Investigated the final 5 uncovered lines** (`dashboard/views.py:287-288`,
+  `palamedes/settings.py:175-176`, `palamedes/urls.py:49`) to confirm none
+  are worth chasing:
+  - `dashboard/views.py:287-288` — unreachable dead code inside the known-broken
+    `PLEDGE_CLASS` bulk-dues branch (issue #50); already correctly pinned in
+    Phase 5.
+  - `palamedes/settings.py:175-176` — **correction to a Phase 6 note below**,
+    which had the branch backwards. This dev machine's `.env` has real AWS
+    credentials set, so `if AWS_ACCESS_KEY_ID:` (S3 storage) is the branch
+    that's *covered*; it's the local-dev-storage `else` branch (lines
+    175-176) that's unreachable here. Either way, this is a module-level
+    settings branch decided once at process start by environment
+    configuration — not something a test can toggle within a run.
+  - `palamedes/urls.py:49` (`if settings.DEBUG: urlpatterns += static(...)`)
+    — confirmed via direct check that `.env` sets `DEBUG=True`, yet the line
+    is still never covered. Root cause: Django's test runner calls
+    `setup_test_environment()`, which force-sets `settings.DEBUG = False` for
+    the duration of `manage.py test` regardless of `.env` — this is
+    documented Django test-runner behavior, not a project bug. The line is
+    structurally unreachable under the standard test command.
+
+  All three remaining gaps are environment/test-runner artifacts rather than
+  untested application logic. **99% is effectively the ceiling** for this
+  codebase under `manage.py test` — no further chasing needed.
+
+Branch: `tests/phase-7-coverage-gaps`, 1 commit, not yet merged — pending
+user check-in. This is the final phase of the original plan.
 
 ---
 
-## Current coverage snapshot (after Phase 6)
+## Final coverage snapshot (after Phase 7)
 
-`coverage run manage.py test && coverage report -m` (full suite, 229 tests):
+`coverage run manage.py test && coverage report -m` (full suite, 248 tests):
 
-- `homepage/`, `users/`: **100%** everywhere (unchanged since Phase 2).
+- `homepage/`, `users/`: **100%** everywhere.
 - `dashboard/`: `models.py`, `forms.py`, `admin.py`, `urls.py` all **100%**.
-  `views.py` at **99%** (2 unreachable lines inside the known-broken
-  `PLEDGE_CLASS` branch, issue #50).
-- `palamedes/settings.py` at 96% (AWS S3 branch, only exercised when
-  `AWS_ACCESS_KEY_ID` is set — genuinely out of scope for a local/CI test
-  run), `urls.py` at 89% (DEBUG-only static media route).
-- Project `TOTAL`: **99%** (up from 92% after Phase 5). Only Phase 7 remains
-  — admin.py smoke tests for users/dashboard (already at 100% coverage
-  incidentally, since they're purely declarative, but not yet deliberately
-  tested) and a final sweep for anything missed.
+  `views.py` at **99%** (2 unreachable lines, issue #50).
+- `palamedes/settings.py` at 96% (AWS S3 vs. local-storage branch — env-decided
+  at process start, see Phase 7 note above), `urls.py` at 89% (DEBUG-gated
+  static media route — unreachable under Django's test runner, see Phase 7
+  note above).
+- Project `TOTAL`: **99%**, well past the original 80% target.
+
+## Task summary
+
+All 7 phases of the original plan are complete: 248 tests across `homepage`,
+`users`, and `dashboard`, 99% project-wide line coverage, zero production code
+changes (tests only, pinning current behavior per the agreed bug-handling
+policy), and 6 GitHub issues filed for genuine bugs found along the way
+(#49-#54, see Phase 6 above) for a future fix-bugs pass.

--- a/palamedes/dashboard/tests/test_admin.py
+++ b/palamedes/dashboard/tests/test_admin.py
@@ -1,4 +1,104 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
 
-# HousePointAdmin / DueAdmin / TaskAdmin / AnnouncementAdmin smoke tests —
-# Phase 7.
+from dashboard.models import Announcement, Due, HousePoint, Task
+from palamedes.test_helpers import PLAIN_STATIC_STORAGE, make_chapter_with_positions, make_user
+from users.models import CustomUser
+
+
+@PLAIN_STATIC_STORAGE
+class AdminSmokeTests(TestCase):
+    """HousePointAdmin / DueAdmin / TaskAdmin / AnnouncementAdmin are purely
+    declarative (list_display/list_filter/search_fields only, no custom
+    methods), so these tests exercise the changelist/change views end to end
+    against real rows rather than just asserting registration."""
+
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.member = make_user(chapter=self.chapter, position=self.positions["No Position"], username="brother1")
+        self.superuser = CustomUser.objects.create_superuser(
+            username="admin", email="admin@example.com", password="testpass123!"
+        )
+        self.client.force_login(self.superuser)
+
+    def test_housepoint_changelist_renders_and_filters(self):
+        HousePoint.objects.create(
+            user=self.member, chapter=self.chapter, submitted_by=self.member, amount=5, description="Attended event"
+        )
+        response = self.client.get(
+            reverse("admin:dashboard_housepoint_changelist"),
+            {"status__exact": "PENDING", "chapter__id__exact": self.chapter.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.member.username)
+
+    def test_housepoint_search_renders(self):
+        HousePoint.objects.create(
+            user=self.member, chapter=self.chapter, submitted_by=self.member, amount=5, description="Attended event"
+        )
+        response = self.client.get(reverse("admin:dashboard_housepoint_changelist"), {"q": self.member.username})
+        self.assertEqual(response.status_code, 200)
+
+    def test_housepoint_change_view_renders(self):
+        point = HousePoint.objects.create(
+            user=self.member, chapter=self.chapter, submitted_by=self.member, amount=5, description="Attended event"
+        )
+        response = self.client.get(reverse("admin:dashboard_housepoint_change", args=[point.pk]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_due_changelist_renders_and_filters(self):
+        Due.objects.create(title="Fall Dues", amount=100, due_date=timezone.now().date(), assigned_to=self.member)
+        response = self.client.get(
+            reverse("admin:dashboard_due_changelist"), {"is_paid__exact": "0", "is_template__exact": "0"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Fall Dues")
+
+    def test_due_change_view_renders(self):
+        due = Due.objects.create(title="Fall Dues", amount=100, due_date=timezone.now().date(), assigned_to=self.member)
+        response = self.client.get(reverse("admin:dashboard_due_change", args=[due.pk]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_task_changelist_renders_and_filters(self):
+        Task.objects.create(
+            assigned_to=self.member,
+            assigned_by=self.superuser,
+            title="Clean the house",
+            description="Weekly chore",
+            due_date=timezone.now(),
+        )
+        response = self.client.get(
+            reverse("admin:dashboard_task_changelist"),
+            {"completed__exact": "0", "assigned_to__id__exact": self.member.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Clean the house")
+
+    def test_task_change_view_renders(self):
+        task = Task.objects.create(
+            assigned_to=self.member,
+            assigned_by=self.superuser,
+            title="Clean the house",
+            description="Weekly chore",
+            due_date=timezone.now(),
+        )
+        response = self.client.get(reverse("admin:dashboard_task_change", args=[task.pk]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_announcement_changelist_renders_and_filters(self):
+        Announcement.objects.create(
+            chapter=self.chapter, author=self.superuser, title="Chapter Meeting", content="Meet at 7pm"
+        )
+        response = self.client.get(
+            reverse("admin:dashboard_announcement_changelist"), {"chapter__id__exact": self.chapter.pk}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Chapter Meeting")
+
+    def test_announcement_change_view_renders(self):
+        announcement = Announcement.objects.create(
+            chapter=self.chapter, author=self.superuser, title="Chapter Meeting", content="Meet at 7pm"
+        )
+        response = self.client.get(reverse("admin:dashboard_announcement_change", args=[announcement.pk]))
+        self.assertEqual(response.status_code, 200)

--- a/palamedes/users/tests/test_admin.py
+++ b/palamedes/users/tests/test_admin.py
@@ -1,3 +1,74 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# PositionAdmin / ChapterAdmin / CustomUserAdmin smoke tests — Phase 7.
+from palamedes.test_helpers import PLAIN_STATIC_STORAGE, make_chapter_with_positions, make_user
+from users.models import CustomUser
+
+
+@PLAIN_STATIC_STORAGE
+class AdminSmokeTests(TestCase):
+    """PositionAdmin / ChapterAdmin / CustomUserAdmin are purely declarative
+    (list_display/list_filter/search_fields/fieldsets only, no custom
+    methods), so these tests exercise the changelist/add/change views end to
+    end against real rows rather than just asserting registration."""
+
+    def setUp(self):
+        self.chapter, self.positions = make_chapter_with_positions()
+        self.superuser = CustomUser.objects.create_superuser(
+            username="admin", email="admin@example.com", password="testpass123!"
+        )
+        self.client.force_login(self.superuser)
+
+    def test_chapter_changelist_renders(self):
+        response = self.client.get(reverse("admin:users_chapter_changelist"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.chapter.name)
+
+    def test_chapter_search_renders(self):
+        response = self.client.get(reverse("admin:users_chapter_changelist"), {"q": "Riverside"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.chapter.name)
+
+    def test_chapter_add_view_renders(self):
+        response = self.client.get(reverse("admin:users_chapter_add"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_chapter_change_view_renders(self):
+        response = self.client.get(reverse("admin:users_chapter_change", args=[self.chapter.pk]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_position_changelist_renders_and_filters_by_chapter(self):
+        response = self.client.get(
+            reverse("admin:users_position_changelist"), {"chapter__id__exact": self.chapter.pk}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "President")
+
+    def test_position_search_renders(self):
+        response = self.client.get(reverse("admin:users_position_changelist"), {"q": "President"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_position_change_view_renders(self):
+        position = self.positions["President"]
+        response = self.client.get(reverse("admin:users_position_change", args=[position.pk]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_customuser_changelist_renders_and_filters(self):
+        member = make_user(chapter=self.chapter, position=self.positions["No Position"], username="brother1")
+        response = self.client.get(
+            reverse("admin:users_customuser_changelist"),
+            {"chapter__id__exact": self.chapter.pk, "status__exact": "ACT", "is_staff__exact": "0"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, member.username)
+
+    def test_customuser_change_view_renders_with_fraternity_fieldset(self):
+        member = make_user(chapter=self.chapter, position=self.positions["Treasurer"], username="brother2")
+        response = self.client.get(reverse("admin:users_customuser_change", args=[member.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Fraternity Info")
+
+    def test_customuser_add_view_renders_with_fraternity_fieldset(self):
+        response = self.client.get(reverse("admin:users_customuser_add"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Fraternity Info")


### PR DESCRIPTION
## Summary
- Phase 7 of the multi-phase test suite effort (see docs/testing/progress.md for full status) -- the final phase, closing out coverage gaps and wrapping up.
- Adds 19 admin.py smoke tests: 10 for `users` (PositionAdmin/ChapterAdmin/CustomUserAdmin), 9 for `dashboard` (HousePointAdmin/DueAdmin/TaskAdmin/AnnouncementAdmin). These admin classes are purely declarative (list_display/list_filter/search_fields/fieldsets, no custom methods), so they already showed 100% coverage incidentally -- these tests make that coverage deliberate by driving the real changelist/search/add/change admin views against actual rows for every registered model.
- Investigated the 3 remaining uncovered-line clusters and confirmed none are worth chasing further -- all are environment/test-runner artifacts, not untested application logic:
  - `dashboard/views.py:287-288` -- unreachable dead code inside the already-pinned broken `PLEDGE_CLASS` branch (issue #50).
  - `palamedes/settings.py:175-176` -- the AWS S3 vs. local-storage branch is decided once at process start by whether `AWS_ACCESS_KEY_ID` is set. Also corrects an earlier note that had this branch backwards for this dev machine's `.env` (which does set real AWS creds).
  - `palamedes/urls.py:49` -- confirmed Django's test runner (`setup_test_environment()`) force-sets `settings.DEBUG = False` for the duration of `manage.py test`, so the `if settings.DEBUG:` static-media route is structurally unreachable under the standard test command, regardless of `.env`.
- Result: full project suite now **248 tests**, all passing. Project-wide coverage `TOTAL` holds at **99%** (up from 0% at the start of this task) -- effectively the ceiling given the constraints above.
- No production code changes -- tests only, per the bug-handling decision from the start of this task (pin current behavior, don't fix).

## Task wrap-up
This is the final phase of the original 7-phase plan. Across all phases: 248 tests added from zero, 99% project-wide line coverage (well past the original 80% target), and 6 GitHub issues filed for genuine bugs discovered along the way (#49-#54) for a future fix-bugs pass.

## Test plan
- [x] python manage.py test users.tests.test_admin -- 10 tests, all pass
- [x] python manage.py test dashboard.tests.test_admin -- 9 tests, all pass
- [x] python manage.py test (full suite) -- 248 tests, all pass, no regressions
- [x] coverage run manage.py test && coverage report -m -- TOTAL 99%, only environment/test-runner-artifact lines remain uncovered

Generated with Claude Code
